### PR TITLE
[Feat] TopBar 컴포넌트 구현 #7

### DIFF
--- a/src/assets/icons/back.svg
+++ b/src/assets/icons/back.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 44 45" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M25.5999 29.7L18.3999 22.5L25.5999 15.3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/clear.svg
+++ b/src/assets/icons/clear.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 12C21 7.03125 16.9688 3 12 3C7.03125 3 3 7.03125 3 12C3 16.9688 7.03125 21 12 21C16.9688 21 21 16.9688 21 12Z" fill="#E1E1E1"/>
+<path d="M15 15L9 9M9 15L15 9" stroke="#B0B5BC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/x-icon.svg
+++ b/src/assets/icons/x-icon.svg
@@ -1,4 +1,11 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 12C21 7.03125 16.9688 3 12 3C7.03125 3 3 7.03125 3 12C3 16.9688 7.03125 21 12 21C16.9688 21 21 16.9688 21 12Z" fill="#E1E1E1"/>
-<path d="M15 15L9 9M9 15L15 9" stroke="#B0B5BC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 44 45" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_44_606)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.343 16.8431C16.6034 16.5828 17.0255 16.5828 17.2859 16.8431L27.6568 27.214C27.9171 27.4744 27.9171 27.8965 27.6568 28.1568C27.3964 28.4172 26.9743 28.4172 26.7139 28.1568L16.343 17.7859C16.0827 17.5256 16.0827 17.1035 16.343 16.8431Z" fill="currentColor"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M27.657 16.8431C27.9173 17.1035 27.9173 17.5256 27.657 17.7859L17.2861 28.1568C17.0257 28.4172 16.6036 28.4172 16.3432 28.1568C16.0829 27.8965 16.0829 27.4744 16.3432 27.214L26.7141 16.8431C26.9745 16.5828 27.3966 16.5828 27.657 16.8431Z" fill="currentColor"/>
+</g>
+<defs>
+<clipPath id="clip0_44_606">
+<rect width="16" height="16" fill="white" transform="translate(22 11.1863) rotate(45)"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Icon from '@/shared/components/icon';
-import SearchTextField from '@/shared/components/search-text-field';
+import SearchTextField from '@/shared/components/text-field/search-text-field';
+import TopBar from '@/shared/layouts/top-bar';
 
 export default function MainPage() {
   const [q, setQ] = useState('');
@@ -11,11 +12,14 @@ export default function MainPage() {
       <h2 className="text-head2 text-secondary">헤드2 20/SB</h2>
 
       <Icon name="home" size={2.4} className="text-black" />
+      <TopBar title="타이틀" showBack onBack={() => history.back()} />
 
+      <TopBar title="타이틀" showClose onClose={() => console.log('close')} />
       <SearchTextField
         defaultValue="초기값"
         onSubmit={(v) => console.log('submit(uncontrolled):', v)}
         className="mt-2"
+        showBackButton={false}
       />
       <SearchTextField
         defaultValue="초기값"

--- a/src/shared/components/text-field/search-text-field.tsx
+++ b/src/shared/components/text-field/search-text-field.tsx
@@ -77,7 +77,7 @@ export default function SearchTextField({
   );
 
   const inputClass =
-    'flex-1 bg-transparent outline-none placeholder:text-gray-400 text-body2 text-gray-900';
+    'flex-1 bg-transparent outline-none placeholder:text-gray-400 text-body4 text-gray-900';
 
   return (
     <form
@@ -140,7 +140,7 @@ export default function SearchTextField({
             >
               <Icon
                 className="text-gray-300"
-                name="x-icon"
+                name="clear"
                 size={2.4}
                 ariaHidden
               />

--- a/src/shared/constants/icons.ts
+++ b/src/shared/constants/icons.ts
@@ -1,5 +1,6 @@
 export const ICONS = [
   "arrow",
+  "clear",
   "home",
   "search",
   "x-icon"

--- a/src/shared/layouts/top-bar.tsx
+++ b/src/shared/layouts/top-bar.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import Icon from '@/shared/components/icon';
+
+type TopBarProps = {
+  title?: React.ReactNode;
+  showBack?: boolean;
+  onBack?: () => void;
+  showClose?: boolean;
+  onClose?: () => void;
+  className?: string;
+  sticky?: boolean;
+  shadow?: boolean;
+  leftSlot?: React.ReactNode;
+  rightSlot?: React.ReactNode;
+};
+
+export default function TopBar({
+  title,
+  showBack = false,
+  onBack,
+  showClose = false,
+  onClose,
+  className = '',
+  sticky,
+  leftSlot,
+  rightSlot,
+}: TopBarProps) {
+  return (
+    <header
+      className={[
+        'w-full bg-white',
+        'px-[0.8rem]',
+        'h-[4.4rem]',
+        'grid items-center',
+        'grid-cols-[3.2rem_1fr_3.2rem]',
+        sticky ? 'sticky top-0 z-[var(--z-header)]' : '',
+        className,
+      ].join(' ')}
+      role="banner"
+    >
+      <div className="justify-self-start">
+        {leftSlot ??
+          (showBack ? (
+            <button
+              type="button"
+              aria-label="뒤로가기"
+              onClick={onBack}
+              className="text-black"
+            >
+              <Icon name="back" size={4.4} ariaHidden />
+            </button>
+          ) : (
+            <span aria-hidden className="block w-[3.2rem]" />
+          ))}
+      </div>
+
+      <h1 className="text-body3 truncate text-center text-gray-900">{title}</h1>
+
+      <div className="justify-self-end">
+        {rightSlot ??
+          (showClose ? (
+            <button
+              type="button"
+              aria-label="닫기"
+              onClick={onClose}
+              className="text-gray-500"
+            >
+              <Icon name="x-icon" size={4.4} ariaHidden />
+            </button>
+          ) : (
+            <span aria-hidden className="block w-[4.4rem]" />
+          ))}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #7

## 🔎 What is this PR?

* 상단 바 **TopBar** 컴포넌트 추가
* 좌측 **뒤로가기**, 가운데 **타이틀(body3 14/SB)**, 우측 **닫기(X)** 지원
* 버튼 유무에 상관없이 타이틀 **항상 중앙 정렬** 유지(3열 grid)

## ✅ 변경사항

* `shared/components/top-bar.tsx` 생성

  * Props

    * `title?: React.ReactNode` – 중앙 타이틀(텍스트/노드)
    * `showBack?: boolean` / `onBack?: () => void`
    * `showClose?: boolean` / `onClose?: () => void`
    * `className?: string`
    * `sticky?: boolean` – 상단 고정
    * `leftSlot?: React.ReactNode` / `rightSlot?: React.ReactNode` – 아이콘 오버라이드
* 디자인 시스템:

  * 타이포: `.text-body3`(14px, SemiBold, LH 150%, letter-spacing -2.5%)
  * 컬러: `text-gray-900`, 버튼 `text-black`/`text-gray-500`


### 사용 예시

```tsx
<TopBar title="타이틀" showBack onBack={() => history.back()} sticky shadow />
<TopBar title="타이틀" showClose onClose={() => setOpen(false)} />
```

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video
<img width="858" height="192" alt="image" src="https://github.com/user-attachments/assets/171e0ed9-6169-44b6-8808-63475b4ecedf" />

