### PR TITLE
[Feat] 메인 섹션 더보기 클릭 시 이동하는 section 페이지 구현 #13

### DIFF
--- a/src/pages/main/components/main-header.tsx
+++ b/src/pages/main/components/main-header.tsx
@@ -66,7 +66,7 @@ export default function Header({
 
         <div className="flex items-center">
           {rightSlot ?? (
-            <button aria-label="검색" className="text-black">
+            <button aria-label="검색" className="cursor-pointer text-black">
               <Icon name="search" width={2.4} />
             </button>
           )}

--- a/src/pages/main/components/product-card.tsx
+++ b/src/pages/main/components/product-card.tsx
@@ -12,15 +12,28 @@ type Props = {
 };
 
 function ProductCard({ product, variant = 'compact', className }: Props) {
-  const { image, store, name, discount, price, originalPrice, remainingBadge, hours, distanceKm } =
-    product;
+  const {
+    image,
+    store,
+    name,
+    discount,
+    price,
+    originalPrice,
+    remainingBadge,
+    hours,
+    distanceKm,
+  } = product;
 
   const Price = () => (
     <div className="flex items-center gap-[0.4rem]">
-      {discount > 0 && <span className="text-caption1 text-primary">{discount}%</span>}
+      {discount > 0 && (
+        <span className="text-caption1 text-primary">{discount}%</span>
+      )}
       <span className="text-body3 text-black">{formatKRW(price)}</span>
       {originalPrice && (
-        <span className="text-caption2 text-gray-300">{formatKRW(originalPrice)}</span>
+        <span className="text-caption2 text-gray-300">
+          {formatKRW(originalPrice)}
+        </span>
       )}
     </div>
   );
@@ -38,15 +51,24 @@ function ProductCard({ product, variant = 'compact', className }: Props) {
 
   if (variant === 'wide') {
     return (
-      <article className={cn('relative w-full overflow-hidden', className)}>
+      <article
+        className={cn(
+          'relative w-full flex-col gap-[1rem] overflow-hidden',
+          className,
+        )}
+      >
         <div className="relative">
-          <img src={image} alt={name} className="h-[14rem] w-full rounded-[4px] object-cover" />
+          <img
+            src={image}
+            alt={name}
+            className="h-[16rem] w-full rounded-[4px] object-cover"
+          />
           {remainingBadge && <Badge>{remainingBadge}</Badge>}
         </div>
         <div className="flex-col gap-[0.2rem]">
           <div className="flex-col">
-            <h4 className="text-caption3 text-black">{store}</h4>
-            <h3 className="text-caption2 line-clamp-1 text-black">{name}</h3>
+            <h4 className="text-caption1 text-black">{store}</h4>
+            <h3 className="text-body3 text-black">{name}</h3>
           </div>
           <Price />
           <Meta />
@@ -59,13 +81,17 @@ function ProductCard({ product, variant = 'compact', className }: Props) {
   return (
     <article className={cn('relative w-full overflow-hidden', className)}>
       <div className="relative">
-        <img src={image} alt={name} className="h-[14rem] w-full rounded-[4px] object-cover" />
+        <img
+          src={image}
+          alt={name}
+          className="h-[14rem] w-full rounded-[4px] object-cover"
+        />
         {remainingBadge && <Badge>{remainingBadge}</Badge>}
       </div>
-      <div className="mt-[1rem] flex flex-col gap-[0.2rem]">
-        <div className="flex flex-col">
+      <div className="mt-[1rem] flex-col gap-[0.2rem]">
+        <div className="flex-col">
           <h4 className="text-caption3 text-black">{store}</h4>
-          <h3 className="text-caption2 line-clamp-1 text-black">{name}</h3>
+          <h3 className="text-caption2 text-black">{name}</h3>
         </div>
         <Price />
         <Meta />

--- a/src/pages/main/components/section-header.tsx
+++ b/src/pages/main/components/section-header.tsx
@@ -1,11 +1,17 @@
-function SectionHeader({ title, onMoreClick }: { title: string; onMoreClick?: () => void }) {
+function SectionHeader({
+  title,
+  onMoreClick,
+}: {
+  title: string;
+  onMoreClick?: () => void;
+}) {
   return (
     <div className="flex items-center justify-between pr-[2rem]">
       <h2 className="text-body1 text-black">{title}</h2>
       <button
         type="button"
         onClick={onMoreClick}
-        className="text-caption2 text-gray-300 underline"
+        className="text-caption2 cursor-pointer text-gray-300 underline"
         aria-label={`${title} 더보기`}
       >
         더보기

--- a/src/pages/main/components/section-list.tsx
+++ b/src/pages/main/components/section-list.tsx
@@ -1,29 +1,51 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import SectionHeader from '@/pages/main/components/section-header';
 import { cn } from '@/shared/libs/cn';
+import type { SectionKey } from '@/shared/constants/sections';
 
 type Props = {
   title: string;
+  sectionKey: SectionKey;
   children: React.ReactNode;
   itemWidthClass?: string;
   className?: string;
   listClassName?: string;
+  mode?: 'delivery' | 'pickup';
 };
 
-function Section({ title, children, itemWidthClass, className, listClassName }: Props) {
+export default function Section({
+  title,
+  sectionKey,
+  children,
+  itemWidthClass,
+  className,
+  listClassName,
+  mode = 'delivery',
+}: Props) {
   const items = React.Children.toArray(children);
+  const navigate = useNavigate();
 
   return (
     <section className={cn('flex-col gap-[1.2rem]', className)}>
-      <SectionHeader title={title} onMoreClick={() => alert(`${title} 더보기 클릭!`)} />
-
+      <SectionHeader
+        title={title}
+        onMoreClick={() => navigate(`/main/${sectionKey}?mode=${mode}`)}
+      />
       <div
-        className={cn('scrollbar-hide flex gap-[1.2rem] overflow-x-auto', listClassName)}
+        className={cn(
+          'scrollbar-hide flex gap-[1.2rem] overflow-x-auto',
+          listClassName,
+        )}
         role="list"
         aria-label={`${title} 목록`}
       >
         {items.map((child, i) => (
-          <div key={i} role="listitem" className={cn('shrink-0 snap-start', itemWidthClass)}>
+          <div
+            key={i}
+            role="listitem"
+            className={cn('shrink-0', itemWidthClass)}
+          >
             {child}
           </div>
         ))}
@@ -31,5 +53,3 @@ function Section({ title, children, itemWidthClass, className, listClassName }: 
     </section>
   );
 }
-
-export default Section;

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -5,14 +5,29 @@ import ProductCard from '@/pages/main/components/product-card';
 import Section from '@/pages/main/components/section-list';
 import HeroBanner from '@/pages/main/components/banner';
 import { mockDeliveryProducts, mockPickupProducts } from '@/shared/mocks';
+import { SECTION_META, type SectionKey } from '@/shared/constants/sections';
 
 export default function MainPage() {
   const [mode, setMode] = useState<Mode>('delivery');
 
-  const current = useMemo(
+  const data = useMemo(
     () => (mode === 'delivery' ? mockDeliveryProducts : mockPickupProducts),
     [mode],
   );
+
+  const ordered: SectionKey[] = [
+    'nearby',
+    'new',
+    'lastcall',
+    'breakfast',
+    'dessert',
+    'now',
+  ];
+
+  const getTitle = (key: SectionKey) => {
+    const t = SECTION_META[key].title;
+    return typeof t === 'string' ? t : t[mode];
+  };
 
   return (
     <div className="h-full w-full bg-white pb-[2.8rem]">
@@ -28,43 +43,23 @@ export default function MainPage() {
         </div>
 
         <div className="flex-col gap-[2.8rem] pl-[2rem]">
-          <Section title="내 주변 상점을 둘러보세요">
-            {current.map((p) => (
-              <ProductCard key={`s1-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
-
-          <Section title="새로 입점했어요">
-            {current.map((p) => (
-              <ProductCard key={`s2-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
-
-          <Section title="곧 품절이에요">
-            {current.map((p) => (
-              <ProductCard key={`s3-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
-
-          <Section title="아침 드실 시간이에요">
-            {current.map((p) => (
-              <ProductCard key={`s4-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
-
-          <Section title="달달한 게 땡길 때">
-            {current.map((p) => (
-              <ProductCard key={`s5-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
-
-          <Section
-            title={mode === 'delivery' ? '지금 바로 배달 받아보세요' : '지금 바로 픽업 가능해요'}
-          >
-            {current.map((p) => (
-              <ProductCard key={`s6-${p.id}`} product={p} variant="compact" />
-            ))}
-          </Section>
+          {ordered.map((key) => (
+            <Section
+              key={key}
+              sectionKey={key}
+              title={getTitle(key)}
+              mode={mode}
+              itemWidthClass="w-[16.5rem]"
+            >
+              {data.map((p) => (
+                <ProductCard
+                  key={`${key}-${p.id}`}
+                  product={p}
+                  variant="compact"
+                />
+              ))}
+            </Section>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/main/section-list/section-list-page.tsx
+++ b/src/pages/main/section-list/section-list-page.tsx
@@ -1,0 +1,36 @@
+import { useParams, useSearchParams } from 'react-router-dom';
+import {
+  SECTION_META,
+  SECTION_KEYS,
+  type SectionKey,
+} from '@/shared/constants/sections';
+import ProductCard from '@/pages/main/components/product-card';
+import { mockDeliveryProducts, mockPickupProducts } from '@/shared/mocks';
+
+export default function SectionListPage() {
+  const { section } = useParams<{ section: SectionKey }>();
+  const [sp] = useSearchParams();
+  const mode = (sp.get('mode') ?? 'delivery') as 'delivery' | 'pickup';
+
+  if (!section || !SECTION_KEYS.includes(section)) {
+    return <div className="p-6">존재하지 않는 섹션입니다.</div>;
+  }
+
+  const rawTitle = SECTION_META[section].title;
+  const title = typeof rawTitle === 'string' ? rawTitle : rawTitle[mode];
+
+  const data = mode === 'delivery' ? mockDeliveryProducts : mockPickupProducts;
+
+  return (
+    <div className="px-5 pb-8">
+      <header className="py-3 text-center text-[18px] font-semibold">
+        {title}
+      </header>
+      <div className="space-y-6">
+        {data.map((p) => (
+          <ProductCard key={p.id} product={p} variant="wide" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/main/section-list/section-list-page.tsx
+++ b/src/pages/main/section-list/section-list-page.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import {
   SECTION_META,
   SECTION_KEYS,
@@ -6,10 +6,13 @@ import {
 } from '@/shared/constants/sections';
 import ProductCard from '@/pages/main/components/product-card';
 import { mockDeliveryProducts, mockPickupProducts } from '@/shared/mocks';
+import TopBar from '@/shared/layouts/top-bar';
 
 export default function SectionListPage() {
   const { section } = useParams<{ section: SectionKey }>();
   const [sp] = useSearchParams();
+  const navigate = useNavigate();
+
   const mode = (sp.get('mode') ?? 'delivery') as 'delivery' | 'pickup';
 
   if (!section || !SECTION_KEYS.includes(section)) {
@@ -22,11 +25,10 @@ export default function SectionListPage() {
   const data = mode === 'delivery' ? mockDeliveryProducts : mockPickupProducts;
 
   return (
-    <div className="px-5 pb-8">
-      <header className="py-3 text-center text-[18px] font-semibold">
-        {title}
-      </header>
-      <div className="space-y-6">
+    <div className="pb-8">
+      <TopBar title={title} showBack onBack={() => navigate(-1)} sticky />
+
+      <div className="flex-col gap-[2rem] px-[2rem] pt-[0.8rem]">
         {data.map((p) => (
           <ProductCard key={p.id} product={p} variant="wide" />
         ))}

--- a/src/shared/constants/sections.ts
+++ b/src/shared/constants/sections.ts
@@ -1,0 +1,28 @@
+export const SECTION_KEYS = [
+  'nearby',
+  'new',
+  'lastcall',
+  'breakfast',
+  'dessert',
+  'now',
+] as const;
+
+export type SectionKey = (typeof SECTION_KEYS)[number];
+
+type SectionMeta = {
+  title: string | { delivery: string; pickup: string };
+};
+
+export const SECTION_META: Record<SectionKey, SectionMeta> = {
+  nearby: { title: '내 주변 상점을 둘러보세요' },
+  new: { title: '새로 입점했어요' },
+  lastcall: { title: '곧 품절이에요' },
+  breakfast: { title: '아침 드실 시간이에요' },
+  dessert: { title: '달달한 게 땡길 때' },
+  now: {
+    title: {
+      delivery: '지금 바로 배달 받아보세요',
+      pickup: '지금 바로 픽업할 수 있어요',
+    },
+  },
+};

--- a/src/shared/layouts/top-bar.tsx
+++ b/src/shared/layouts/top-bar.tsx
@@ -40,7 +40,12 @@ export default function TopBar({
       <div className="justify-self-start">
         {leftSlot ??
           (showBack ? (
-            <button type="button" aria-label="뒤로가기" onClick={onBack} className="text-black">
+            <button
+              type="button"
+              aria-label="뒤로가기"
+              onClick={onBack}
+              className="cursor-pointer text-black"
+            >
               <Icon name="back" size={4.4} ariaHidden />
             </button>
           ) : (
@@ -53,7 +58,12 @@ export default function TopBar({
       <div className="justify-self-end">
         {rightSlot ??
           (showClose ? (
-            <button type="button" aria-label="닫기" onClick={onClose} className="text-gray-500">
+            <button
+              type="button"
+              aria-label="닫기"
+              onClick={onClose}
+              className="cursor-pointer text-gray-500"
+            >
               <Icon name="x-icon" size={4.4} ariaHidden />
             </button>
           ) : (

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -1,8 +1,11 @@
 import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
-const Layout = lazy(() => import('@/shared/layouts/layout.jsx'));
-const MainPage = lazy(() => import('@/pages/main/main-page.js'));
+const Layout = lazy(() => import('@/shared/layouts/layout'));
+const MainPage = lazy(() => import('@/pages/main/main-page'));
+const SectionListPage = lazy(
+  () => import('@/pages/main/section-list/section-list-page'),
+);
 const MapPage = lazy(() => import('@/pages/map/map-page'));
 
 export const router = createBrowserRouter([
@@ -10,6 +13,7 @@ export const router = createBrowserRouter([
     element: <Layout />,
     children: [
       { index: true, element: <MainPage /> },
+      { path: '/main/:section', element: <SectionListPage /> },
       { path: 'map', element: <MapPage /> },
     ],
   },


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #13


## 🔎 What is this PR?

* 메인 홈의 각 섹션에서 **“더보기” 클릭 시 이동**하는 **섹션 리스트 페이지** 구현
* URL 구조: `/main/:section?mode=delivery|pickup` (섹션은 영문 슬러그, 모드는 쿼리)
* 상단 **TopBar**(좌측 back 아이콘) 적용 및 **sticky 헤더** 처리
* `SECTION_META`의 타이틀을 **배달/픽업 모드에 따라 분기**하여 표시

## ✅ 변경사항

* **Routing**

  * `createBrowserRouter`에 `path: '/main/:section'` 추가
* **Constants**

  * `SECTION_KEYS`, `SECTION_META` 정의:

    * `now` 섹션은 `{ delivery: '지금 바로 배달 받아보세요', pickup: '지금 바로 픽업할 수 있어요' }` 형태로 분기 지원
* **MainPage → Section 연동**

  * `Section` 컴포넌트에 `sectionKey`/`mode` 전달
  * `onMoreClick` 시 `/main/${sectionKey}?mode=${mode}` 로 네비게이션
* **SectionListPage**

  * `useParams`로 `section` 슬러그 검증
  * `useSearchParams`로 `mode` 파싱(`delivery` 기본)
  * `SECTION_META`에서 모드에 맞는 **타이틀 문자열 정규화** 후 헤더 표시
  * 더미 데이터(`mockDeliveryProducts`/`mockPickupProducts`)로 리스트 렌더(`variant="wide"`)
  * 상단 `TopBar` 사용(좌측 back 아이콘, sticky, 하단 보더)
* **TopBar**

  * 재사용 가능한 레이아웃 헤더: `showBack`, `onBack`, `title`, `sticky` 등 prop 제공

## 💡 해결한 이슈 목록

* [x] 섹션 더보기 → 섹션별 리스트 페이지 이동
* [x] URL 파라미터/쿼리 기반의 상태 처리(`:section`, `?mode=…`)
* [x] 상단 TopBar + 뒤로가기 UX 적용

## 🧪 테스트 방법

1. 메인 페이지에서 각 섹션의 **“더보기”** 클릭

   * 주소가 `/main/<section-slug>?mode=<delivery|pickup>` 형태로 이동해야 함
2. 주소창에서 `?mode=pickup` 으로 변경 후 엔터

   * 섹션 타이틀이 픽업 문구로 바뀌는지 확인
     (예: `now` → “지금 바로 픽업할 수 있어요”)
3. 상단 **뒤로가기** 아이콘 클릭

   * 직전 페이지로 정상 복귀
4. 존재하지 않는 섹션(`:section`)으로 접근 시

   * “존재하지 않는 섹션입니다.” 메시지 노출

## 🧩 코드 스니펫 (요약)

* 라우팅

  ```tsx
  { path: '/main/:section', element: <SectionListPage /> }
  ```
* 섹션 메타

  ```ts
  now: { title: { delivery: '지금 바로 배달 받아보세요', pickup: '지금 바로 픽업할 수 있어요' } }
  ```
* SectionListPage 제목 분기

  ```ts
  const rawTitle = SECTION_META[section].title;
  const title = typeof rawTitle === 'string' ? rawTitle : rawTitle[mode];
  ```


## 🔜 후속 작업

* 실제 API 연동(TanStack Query) 및 무한 스크롤/페이지네이션
* 로딩/빈 상태/에러 상태 UI
* 섹션별 필터/정렬 옵션 확장
* 카드 클릭 시 상세 페이지 라우팅 연계



<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fd117151-12a4-4abb-951a-f5a75f5659c2" />

