### PR TITLE
[Feat] radio tile group 컴포넌트 구현 #9

### DIFF
--- a/src/shared/components/text-field/radio-tile-group.tsx
+++ b/src/shared/components/text-field/radio-tile-group.tsx
@@ -47,18 +47,17 @@ export default function RadioTileGroup({
 
             <div
               className={cn(
-                'flex items-center justify-between rounded-[4px] border px-4 py-4 transition-colors',
-                'border-neutral-200 bg-white',
-                'peer-hover:border-neutral-300',
+                'flex items-center justify-between rounded-[4px] border p-[1.6rem] transition-colors',
+                'border-gray-200 bg-white',
                 'peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200',
-                'peer-checked:border-orange-500 peer-checked:bg-orange-50',
+                'peer-checked:bg-secondary peer-checked:border-primary peer-checked:[&>span:first-child]:text-primary',
                 opt.disabled && 'pointer-events-none opacity-60',
               )}
             >
               <span
                 className={cn(
-                  'text-body3 text-neutral-800',
-                  'peer-checked:text-orange-600',
+                  'text-body3 text-black',
+                  'text-body3 peer-checked:text-primary',
                 )}
               >
                 {opt.label}
@@ -67,8 +66,8 @@ export default function RadioTileGroup({
               {opt.right && (
                 <span
                   className={cn(
-                    'text-body4 text-neutral-500',
-                    'peer-checked:text-orange-600',
+                    'text-body4 text-black',
+                    'text-body4 peer-checked:text-primary',
                   )}
                 >
                   {opt.right}


### PR DESCRIPTION
Closes #9 

🔎 What is this PR?

- 주문 유형/결제 방법 등에서 쓰는 타일형 라디오 입력 컴포넌트 RadioTileGroup를 추가합니다.
- 기본(white/gray) ↔ 선택됨(secondary bg + primary border) 상태 전환, 체크 시 왼쪽 라벨만 primary 컬러 규칙 반영.
- 네이티브 <input type="radio" />를 sr-only로 두고 라벨 전체를 클릭 타깃으로 사용해 접근성과 사용성을 확보했습니다.

💡 해결한 이슈 목록
- 공통 RadioTile 컴포넌트 구현 및 그룹 선택 로직
- 선택 상태 시 배경/보더/라벨 컬러 토글(라벨만 primary)
- disable 상태 처리(포인터 차단 + 투명도)
- 외부 컨테이너 클래스 전달(className)로 레이아웃 유연화

✅ 변경사항

- src/components/common/RadioTileGroup.tsx 추가
- Option, Props 타입 정의 (label, right 지원)
- 스타일 토큰 사용: text-body3, text-body4, bg-secondary, border-primary, text-primary
- cn 유틸로 상태별 클래스 병합

📷 Screenshots or Video
로컬에서 확인: 샘플
```tsx
    <div className="space-y-8">
      {/* 주문 유형 */}
      <section>
        <h3 className="mb-3 text-[16px] font-semibold text-neutral-900">
          주문 유형
        </h3>
        <RadioTileGroup
          name="order-type"
          value={orderType}
          onChange={setOrderType}
          options={[
            {
              value: 'team',
              label: '팀배달',
              right: '오후 8시 15분 이후에 출발합니다',
            },
            {
              value: 'pickup',
              label: '픽업',
              right: '오후 8시 15분 ~ 영업 종료 시',
            },
          ]}
        />
        <p className="mt-2 text-[12px] text-orange-600">
          *출발 시각에 맞추어 순차적으로 배달됩니다
        </p>
      </section>

      {/* 결제 방법 */}
      <section>
        <h3 className="mb-3 text-[16px] font-semibold text-neutral-900">
          결제 방법
        </h3>
        <RadioTileGroup
          name="payment"
          value={payment}
          onChange={setPayment}
          options={[
            { value: 'card', label: '카드 결제' },
            { value: 'cash', label: '현장 결제' },
          ]}
        />
      </section>
    </div>
```