### PR TITLE
[Feat] 메뉴 페이지 UI 구현 #23

### DIFF
--- a/src/pages/main/components/count-badge.tsx
+++ b/src/pages/main/components/count-badge.tsx
@@ -1,6 +1,6 @@
 function Badge({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-primary text-caption4 pointer-events-none absolute top-[1.2rem] left-[1.2rem] rounded-[4px] px-[0.6rem] py-[0.45rem] text-white">
+    <div className="bg-primary caption4 pointer-events-none absolute top-[1.2rem] left-[1.2rem] rounded-[4px] px-[0.6rem] py-[0.45rem] text-white">
       {children}
     </div>
   );

--- a/src/pages/main/components/main-header.tsx
+++ b/src/pages/main/components/main-header.tsx
@@ -41,7 +41,7 @@ export default function Header({
     >
       <div className="flex items-center justify-between">
         <nav
-          className="text-body1 flex gap-[1.6rem]"
+          className="body1 flex gap-[1.6rem]"
           role="tablist"
           aria-label="배송 방식 선택"
         >

--- a/src/pages/main/components/product/product-card.tsx
+++ b/src/pages/main/components/product/product-card.tsx
@@ -12,9 +12,22 @@ export type ProductCardProps = {
   className?: string;
 };
 
-function ProductCard({ product, variant = 'compact', className }: ProductCardProps) {
-  const { image, store, name, discount, price, originalPrice, remainingBadge, hours, distanceKm } =
-    product;
+function ProductCard({
+  product,
+  variant = 'compact',
+  className,
+}: ProductCardProps) {
+  const {
+    image,
+    store,
+    name,
+    discount,
+    price,
+    originalPrice,
+    remainingBadge,
+    hours,
+    distanceKm,
+  } = product;
   const navigate = useNavigate();
 
   if (variant === 'wide') {
@@ -36,10 +49,14 @@ function ProductCard({ product, variant = 'compact', className }: ProductCardPro
         </div>
         <div className="flex-col gap-[0.2rem]">
           <div className="flex-col">
-            <h4 className="text-caption1 text-black">{store}</h4>
-            <h3 className="text-body3 text-black">{name}</h3>
+            <h4 className="caption1 text-black">{store}</h4>
+            <h3 className="body3 text-black">{name}</h3>
           </div>
-          <ProductPrice discount={discount} price={price} originalPrice={originalPrice} />
+          <ProductPrice
+            discount={discount}
+            price={price}
+            originalPrice={originalPrice}
+          />
           <Meta hours={hours} distanceKm={distanceKm} />
         </div>
       </article>
@@ -49,19 +66,30 @@ function ProductCard({ product, variant = 'compact', className }: ProductCardPro
   // compact
   return (
     <article
-      className={cn('relative w-full cursor-pointer overflow-hidden', className)}
+      className={cn(
+        'relative w-full cursor-pointer overflow-hidden',
+        className,
+      )}
       onClick={() => navigate(`/product/${product.id}`)}
     >
       <div className="relative">
-        <img src={image} alt={name} className="h-[14rem] w-full rounded-[4px] object-cover" />
+        <img
+          src={image}
+          alt={name}
+          className="h-[14rem] w-full rounded-[4px] object-cover"
+        />
         {remainingBadge && <Badge>{remainingBadge}</Badge>}
       </div>
       <div className="mt-[1rem] flex-col gap-[0.2rem]">
         <div className="flex-col">
-          <h4 className="text-caption3 text-black">{store}</h4>
-          <h3 className="text-caption2 text-black">{name}</h3>
+          <h4 className="caption3 text-black">{store}</h4>
+          <h3 className="caption2 text-black">{name}</h3>
         </div>
-        <ProductPrice discount={discount} price={price} originalPrice={originalPrice} />
+        <ProductPrice
+          discount={discount}
+          price={price}
+          originalPrice={originalPrice}
+        />
         <Meta hours={hours} distanceKm={distanceKm} />
       </div>
     </article>

--- a/src/pages/main/components/product/product-meta.tsx
+++ b/src/pages/main/components/product/product-meta.tsx
@@ -4,7 +4,7 @@ import type { Product } from '@/shared/types';
 type MetaProps = Pick<Product, 'hours' | 'distanceKm'>;
 
 const Meta = ({ hours, distanceKm }: MetaProps) => (
-  <div className="text-caption4 flex items-center gap-[0.4rem] text-gray-600">
+  <div className="caption4 flex items-center gap-[0.4rem] text-gray-600">
     <span className="flex items-center gap-[0.2rem]">
       <Icon name="cart" size={1.2} />
       {hours}

--- a/src/pages/main/components/product/product-price.tsx
+++ b/src/pages/main/components/product/product-price.tsx
@@ -6,13 +6,21 @@ type ProductPriceProps = {
   originalPrice?: number;
 };
 
-export default function ProductPrice({ discount, price, originalPrice }: ProductPriceProps) {
+export default function ProductPrice({
+  discount,
+  price,
+  originalPrice,
+}: ProductPriceProps) {
   return (
     <div className="flex items-center gap-[0.4rem]">
-      {discount > 0 && <span className="text-caption1 text-primary">{discount}%</span>}
-      <span className="text-body3 text-black">{formatKRW(price)}</span>
+      {discount > 0 && (
+        <span className="caption1 text-primary">{discount}%</span>
+      )}
+      <span className="body3 text-black">{formatKRW(price)}</span>
       {originalPrice && (
-        <span className="text-caption2 text-gray-300">{formatKRW(originalPrice)}</span>
+        <span className="caption2 text-gray-300">
+          {formatKRW(originalPrice)}
+        </span>
       )}
     </div>
   );

--- a/src/pages/main/components/section-header.tsx
+++ b/src/pages/main/components/section-header.tsx
@@ -1,11 +1,17 @@
-function SectionHeader({ title, onMoreClick }: { title: string; onMoreClick?: () => void }) {
+function SectionHeader({
+  title,
+  onMoreClick,
+}: {
+  title: string;
+  onMoreClick?: () => void;
+}) {
   return (
     <div className="flex items-center justify-between pr-[2rem]">
-      <h2 className="text-body1 text-black">{title}</h2>
+      <h2 className="body1 text-black">{title}</h2>
       <button
         type="button"
         onClick={onMoreClick}
-        className="text-caption2 cursor-pointer text-gray-300 underline"
+        className="caption2 cursor-pointer text-gray-300 underline"
         aria-label={`${title} 더보기`}
       >
         더보기

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -56,9 +56,7 @@ export default function MainPage() {
         <div className="flex-col gap-[1.6rem] px-[2rem] pt-[1.6rem]">
           <div className="flex items-center gap-[0.4rem]">
             <Icon name="location" size={2.4} className="text-primary" />
-            <span className="text-body3 text-black">
-              {DEFAULT_LOCATION_LABEL}
-            </span>
+            <span className="body3 text-black">{DEFAULT_LOCATION_LABEL}</span>
           </div>
           <HeroBanner />
         </div>

--- a/src/pages/main/product-detail/components/bottom-cta.tsx
+++ b/src/pages/main/product-detail/components/bottom-cta.tsx
@@ -4,7 +4,7 @@ function BottomCTA({ label, onClick }: { label: string; onClick: () => void }) {
       <button
         type="button"
         onClick={onClick}
-        className="text-body3 w-full rounded-[10px] bg-gray-900 py-[1.6rem] text-white"
+        className="body3 w-full rounded-[10px] bg-gray-900 py-[1.6rem] text-white"
       >
         {label}
       </button>

--- a/src/pages/main/product-detail/components/info-row.tsx
+++ b/src/pages/main/product-detail/components/info-row.tsx
@@ -11,7 +11,7 @@ function InfoRow({
 }) {
   return (
     <div className="flex items-center justify-start gap-[1.2rem]">
-      <div className="text-body4 flex items-center gap-[0.4rem] text-black">
+      <div className="body4 flex items-center gap-[0.4rem] text-black">
         <Icon name={icon} size={2.4} />
         <span>{text}</span>
       </div>

--- a/src/pages/main/product-detail/product-detail-page.tsx
+++ b/src/pages/main/product-detail/product-detail-page.tsx
@@ -90,17 +90,17 @@ export default function ProductDetailPage() {
         <div className="flex-col gap-[2.4rem] px-[2rem] pt-[2rem]">
           <section className="space-y-2">
             <div className="flex-col gap-[0.2rem]">
-              <div className="text-body3 text-black">{store}</div>
-              <h1 className="text-body2 text-black">{name}</h1>
+              <div className="body3 text-black">{store}</div>
+              <h1 className="body2 text-black">{name}</h1>
             </div>
             <div className="flex-col gap-[0.8rem]">
               <div className="flex-items-center gap-[0.4rem]">
                 {discount > 0 && (
-                  <span className="text-primary text-body1">{discount}%</span>
+                  <span className="text-primary body1">{discount}%</span>
                 )}
-                <span className="text-head3 font-bold">{formatKRW(price)}</span>
+                <span className="head3 font-bold">{formatKRW(price)}</span>
                 {originalPrice && (
-                  <span className="text-body2 text-gray-300 line-through">
+                  <span className="body2 text-gray-300 line-through">
                     {formatKRW(originalPrice)}
                   </span>
                 )}
@@ -108,8 +108,8 @@ export default function ProductDetailPage() {
 
               {pickupPrice && (
                 <div className="text-blue flex-items-center gap-[0.4rem]">
-                  <span className="text-body2">픽업 시</span>
-                  <span className="text-head3">{formatKRW(pickupPrice)}</span>
+                  <span className="body2">픽업 시</span>
+                  <span className="head3">{formatKRW(pickupPrice)}</span>
                 </div>
               )}
             </div>
@@ -125,7 +125,7 @@ export default function ProductDetailPage() {
                     className="text-primary flex-row-center cursor-pointer gap-[0.4rem]"
                   >
                     <Icon name="map" size={2.4} />
-                    <span className="text-caption2">지도에서 보기</span>
+                    <span className="caption2">지도에서 보기</span>
                   </button>
                 }
               />
@@ -138,15 +138,15 @@ export default function ProductDetailPage() {
           </section>
           {teamDeliveryAfter && (
             <section>
-              <div className="text-body4 rounded-[4px] bg-gray-50 p-[1.6rem] text-center text-black">
+              <div className="body4 rounded-[4px] bg-gray-50 p-[1.6rem] text-center text-black">
                 {teamDeliveryAfter} 팀배달이 가능한 상품이에요
               </div>
             </section>
           )}
           <section className="flex-col gap-[1.2rem]">
-            <h2 className="text-body1 text-black">상품 설명</h2>
-            <p className="text-body4 text-black">{description}</p>
-            <p className="text-caption1 text-primary pb-[2rem] break-words">
+            <h2 className="body1 text-black">상품 설명</h2>
+            <p className="body4 text-black">{description}</p>
+            <p className="caption1 text-primary pb-[2rem] break-words">
               *본 업소는 (서비스명)의 신선도 관리 기준을 준수합니다. 신선한
               재료로 준비된 밀키트를 안심하고 드셔보세요.
             </p>

--- a/src/pages/menu/components/filter-modal.tsx
+++ b/src/pages/menu/components/filter-modal.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react';
+import Tag from '@/shared/components/chips/tag';
+import RadioTileGroup from '@/shared/components/text-field/radio-tile-group';
+import TopBar from '@/shared/layouts/top-bar';
+import Button from '@/shared/components/button/button';
+import {
+  FILTER_DEFAULT,
+  FOOD_TYPE_OPTIONS,
+  CATEGORY_OPTIONS,
+  PRICE_OPTIONS,
+  RECEIVE_OPTIONS,
+  type FilterState,
+} from '@/pages/menu/constants/filter';
+
+type Props = {
+  open: boolean;
+  value: FilterState;
+  onApply: (v: FilterState) => void;
+  onClose: () => void;
+};
+
+export default function FilterModal({ open, value, onApply, onClose }: Props) {
+  const [draft, setDraft] = React.useState<FilterState>(value);
+
+  React.useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  if (!open) return null;
+
+  const toggleInArray = <T extends string>(arr: T[], k: T): T[] =>
+    arr.includes(k) ? arr.filter((x) => x !== k) : [...arr, k];
+
+  const sameSet = <T extends string>(a: T[], b: T[]) => {
+    if (a.length !== b.length) return false;
+    const as = [...a].sort();
+    const bs = [...b].sort();
+    for (let i = 0; i < as.length; i++) if (as[i] !== bs[i]) return false;
+    return true;
+  };
+  const isSameFilter = (a: FilterState, b: FilterState) =>
+    a.foodType === b.foodType &&
+    a.priceMax === b.priceMax &&
+    sameSet(a.categories, b.categories) &&
+    sameSet(a.receive as string[], b.receive as string[]);
+
+  const changed = !isSameFilter(draft, value);
+
+  return (
+    <div
+      className="fixed inset-0 z-[var(--z-bottom-modal)]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="필터"
+    >
+      <div className="absolute inset-0">
+        <div className="mx-auto flex h-full w-full max-w-[43rem] flex-col bg-white">
+          <TopBar
+            title="필터"
+            showClose
+            onClose={onClose}
+            className="bg-white px-[2rem]"
+          />
+
+          <div className="scrollbar-hide flex-1 flex-col gap-[3.6rem] overflow-y-auto px-[2rem]">
+            <section className="flex-col gap-[1.2rem]">
+              <h3 className="body3 font-medium text-black">음식 타입</h3>
+              <div className="grid grid-cols-2 gap-[1.2rem]">
+                <RadioTileGroup
+                  name="food-type"
+                  value={draft.foodType}
+                  onChange={(v) => setDraft((s) => ({ ...s, foodType: v }))}
+                  options={FOOD_TYPE_OPTIONS.map((o) => ({
+                    value: o.value,
+                    label: o.label,
+                  }))}
+                  className="col-span-2 grid grid-cols-2 gap-[1.2rem]"
+                  rounded="rounded-[1rem]"
+                />
+              </div>
+            </section>
+
+            <section className="flex-col gap-[1.2rem]">
+              <h3 className="body3 font-medium text-black">카테고리</h3>
+              <div className="flex flex-wrap gap-[0.8rem]">
+                {CATEGORY_OPTIONS.map((c) => {
+                  const selected = draft.categories.includes(c);
+                  return (
+                    <Tag
+                      key={c}
+                      selected={selected}
+                      onClick={() =>
+                        setDraft((s) => ({
+                          ...s,
+                          categories: toggleInArray(s.categories, c),
+                        }))
+                      }
+                    >
+                      {c}
+                    </Tag>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="flex-col gap-[1.2rem]">
+              <h3 className="body3 font-medium text-black">가격대</h3>
+              <div className="flex flex-wrap gap-[0.8rem]">
+                {PRICE_OPTIONS.map((p) => {
+                  const selected = draft.priceMax === p.value;
+                  return (
+                    <Tag
+                      key={p.value}
+                      selected={selected}
+                      onClick={() =>
+                        setDraft((s) => ({
+                          ...s,
+                          priceMax: selected ? '' : p.value,
+                        }))
+                      }
+                    >
+                      {p.label}
+                    </Tag>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="flex-col gap-[1.2rem]">
+              <h3 className="body3 font-medium text-black">수령 방법</h3>
+              <div className="flex flex-wrap gap-[0.8rem]">
+                {RECEIVE_OPTIONS.map((r) => {
+                  const selected = draft.receive.includes(r.value);
+                  return (
+                    <Tag
+                      key={r.value}
+                      selected={selected}
+                      onClick={() =>
+                        setDraft((s) => ({
+                          ...s,
+                          receive: toggleInArray(s.receive, r.value),
+                        }))
+                      }
+                    >
+                      {r.label}
+                    </Tag>
+                  );
+                })}
+              </div>
+            </section>
+          </div>
+
+          <div className="sticky right-0 bottom-0 left-0 px-[2rem] pt-[1.2rem] pb-[max(env(safe-area-inset-bottom),2rem)]">
+            <div className="flex items-center gap-[1.2rem]">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setDraft(FILTER_DEFAULT)}
+              >
+                초기화
+              </Button>
+              <Button
+                variant={changed ? 'black' : 'white'}
+                disabled={!changed}
+                className="flex-[2]"
+                onClick={() => {
+                  onApply(draft);
+                  onClose();
+                }}
+              >
+                결과 확인하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/menu/components/list-section.tsx
+++ b/src/pages/menu/components/list-section.tsx
@@ -1,11 +1,21 @@
+// pages/menu/components/list-section.tsx
 import ProductCard from '@/pages/main/components/product/product-card';
 import type { Product } from '@/shared/types';
 import SortFilterRow from '@/pages/menu/components/sort-filter-row';
+import type { SortKey } from '@/pages/menu/constants/sort';
 
-export default function ListSection({ products }: { products: Product[] }) {
+export default function ListSection({
+  products,
+  sort,
+  onOpenSort,
+}: {
+  products: Product[];
+  sort: SortKey;
+  onOpenSort: () => void;
+}) {
   return (
     <div className="scrollbar-hide relative h-[100dvh] w-full flex-col gap-[1.2rem] overflow-y-auto pt-[5rem] pb-[6rem]">
-      <SortFilterRow />
+      <SortFilterRow sort={sort} onOpenSort={onOpenSort} />
       <div className="px-[2rem] pb-[4rem]">
         <div className="flex-col gap-[2.0rem]">
           {products.map((p) => (

--- a/src/pages/menu/components/list-section.tsx
+++ b/src/pages/menu/components/list-section.tsx
@@ -1,0 +1,18 @@
+import ProductCard from '@/pages/main/components/product/product-card';
+import type { Product } from '@/shared/types';
+import SortFilterRow from '@/pages/menu/components/sort-filter-row';
+
+export default function ListSection({ products }: { products: Product[] }) {
+  return (
+    <div className="scrollbar-hide relative h-[100dvh] w-full flex-col gap-[1.2rem] overflow-y-auto pt-[5rem] pb-[6rem]">
+      <SortFilterRow />
+      <div className="px-[2rem] pb-[4rem]">
+        <div className="flex-col gap-[2.0rem]">
+          {products.map((p) => (
+            <ProductCard key={p.id} product={p} variant="wide" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/menu/components/list-section.tsx
+++ b/src/pages/menu/components/list-section.tsx
@@ -4,18 +4,29 @@ import type { Product } from '@/shared/types';
 import SortFilterRow from '@/pages/menu/components/sort-filter-row';
 import type { SortKey } from '@/pages/menu/constants/sort';
 
+type Props = {
+  products: Product[];
+  sort: SortKey;
+  onOpenSort: () => void;
+  onOpenFilter: () => void; // ✅ 추가
+  filterSelected: boolean; // ✅ 추가
+};
+
 export default function ListSection({
   products,
   sort,
   onOpenSort,
-}: {
-  products: Product[];
-  sort: SortKey;
-  onOpenSort: () => void;
-}) {
+  onOpenFilter,
+  filterSelected,
+}: Props) {
   return (
     <div className="scrollbar-hide relative h-[100dvh] w-full flex-col gap-[1.2rem] overflow-y-auto pt-[5rem] pb-[6rem]">
-      <SortFilterRow sort={sort} onOpenSort={onOpenSort} />
+      <SortFilterRow
+        sort={sort}
+        onOpenSort={onOpenSort}
+        onOpenFilter={onOpenFilter}
+        filterSelected={filterSelected}
+      />
       <div className="px-[2rem] pb-[4rem]">
         <div className="flex-col gap-[2.0rem]">
           {products.map((p) => (

--- a/src/pages/menu/components/map-section.tsx
+++ b/src/pages/menu/components/map-section.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Container as MapDiv, Marker, NaverMap } from 'react-naver-maps';
+import type { Product } from '@/shared/types';
+import { getMapInstance } from '@/pages/menu/utils/naver-map';
+import { makeLocationPinHtml } from '@/pages/menu/utils/make-pin';
+
+type Restaurant = { id: number; lat: number; lng: number };
+
+type Props = {
+  center: { lat: number; lng: number };
+  defaultCenter: { lat: number; lng: number };
+  restaurants: Restaurant[];
+  products: Product[];
+  onPickPreview: (p: Product) => void;
+  onMapTap: () => void;
+};
+
+export default function MapSection({
+  center,
+  defaultCenter,
+  restaurants,
+  products,
+  onPickPreview,
+  onMapTap,
+}: Props) {
+  const mapRef = useRef<any>(null);
+  const [mapInstance, setMapInstance] = useState<any>(null);
+
+  const myMarkerIcon = useMemo(() => makeLocationPinHtml('text-primary'), []);
+  const restaurantMarkerIcon = useMemo(
+    () => makeLocationPinHtml('text-primary'),
+    [],
+  );
+
+  const handleMapRef = (node: any) => {
+    mapRef.current = node;
+    const inst = getMapInstance(node);
+    if (inst) setMapInstance(inst);
+  };
+
+  useEffect(() => {
+    const n = (window as any).naver;
+    if (!n?.maps || !mapInstance) return;
+
+    const off: any[] = [];
+    off.push(n.maps.Event.addListener(mapInstance, 'click', onMapTap));
+    off.push(n.maps.Event.addListener(mapInstance, 'tap', onMapTap));
+    return () => off.forEach((h) => n.maps.Event.removeListener(h));
+  }, [mapInstance, onMapTap]);
+
+  return (
+    <MapDiv
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+      }}
+      fallback={
+        <div className="grid h-full place-items-center">지도 로딩 중…</div>
+      }
+    >
+      <NaverMap
+        defaultCenter={defaultCenter}
+        center={center}
+        defaultZoom={16}
+        ref={handleMapRef}
+      >
+        <Marker position={center} icon={myMarkerIcon as any} />
+        {restaurants.map((r, idx) => (
+          <Marker
+            key={r.id}
+            position={{ lat: r.lat, lng: r.lng }}
+            icon={restaurantMarkerIcon as any}
+            onClick={() => onPickPreview(products[idx % products.length])}
+          />
+        ))}
+      </NaverMap>
+    </MapDiv>
+  );
+}

--- a/src/pages/menu/components/menu-header.tsx
+++ b/src/pages/menu/components/menu-header.tsx
@@ -1,5 +1,7 @@
+// pages/menu/components/menu-header.tsx
 import SearchTextField from '@/shared/components/text-field/search-text-field';
 import SortFilterRow from '@/pages/menu/components/sort-filter-row';
+import type { SortKey } from '@/pages/menu/constants/sort';
 
 type Props = {
   mode: 'map' | 'list';
@@ -8,6 +10,8 @@ type Props = {
   onSubmit: (v: string) => void;
   onBack: () => void;
   onClear: () => void;
+  sort: SortKey; // ✅ 추가
+  onOpenSort: () => void; // ✅ 추가
 };
 
 export default function MenuHeader({
@@ -17,6 +21,8 @@ export default function MenuHeader({
   onSubmit,
   onBack,
   onClear,
+  sort,
+  onOpenSort,
 }: Props) {
   return (
     <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
@@ -32,7 +38,7 @@ export default function MenuHeader({
         className="bg-white"
         placeholder="검색어를 입력해주세요."
       />
-      {mode === 'map' && <SortFilterRow />}
+      {mode === 'map' && <SortFilterRow sort={sort} onOpenSort={onOpenSort} />}
     </div>
   );
 }

--- a/src/pages/menu/components/menu-header.tsx
+++ b/src/pages/menu/components/menu-header.tsx
@@ -1,0 +1,38 @@
+import SearchTextField from '@/shared/components/text-field/search-text-field';
+import SortFilterRow from '@/pages/menu/components/sort-filter-row';
+
+type Props = {
+  mode: 'map' | 'list';
+  query: string;
+  setQuery: (v: string) => void;
+  onSubmit: (v: string) => void;
+  onBack: () => void;
+  onClear: () => void;
+};
+
+export default function MenuHeader({
+  mode,
+  query,
+  setQuery,
+  onSubmit,
+  onBack,
+  onClear,
+}: Props) {
+  return (
+    <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
+      <SearchTextField
+        value={query}
+        onChange={setQuery}
+        onSubmit={onSubmit}
+        onBack={onBack}
+        onClear={onClear}
+        autoFocus={false}
+        showBackButton
+        showSearchIcon
+        className="bg-white"
+        placeholder="검색어를 입력해주세요."
+      />
+      {mode === 'map' && <SortFilterRow />}
+    </div>
+  );
+}

--- a/src/pages/menu/components/menu-header.tsx
+++ b/src/pages/menu/components/menu-header.tsx
@@ -1,4 +1,3 @@
-// pages/menu/components/menu-header.tsx
 import SearchTextField from '@/shared/components/text-field/search-text-field';
 import SortFilterRow from '@/pages/menu/components/sort-filter-row';
 import type { SortKey } from '@/pages/menu/constants/sort';
@@ -10,8 +9,10 @@ type Props = {
   onSubmit: (v: string) => void;
   onBack: () => void;
   onClear: () => void;
-  sort: SortKey; // ✅ 추가
-  onOpenSort: () => void; // ✅ 추가
+  sort: SortKey;
+  onOpenSort: () => void;
+  onOpenFilter: () => void;
+  filterSelected: boolean;
 };
 
 export default function MenuHeader({
@@ -23,6 +24,8 @@ export default function MenuHeader({
   onClear,
   sort,
   onOpenSort,
+  onOpenFilter,
+  filterSelected,
 }: Props) {
   return (
     <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
@@ -38,7 +41,14 @@ export default function MenuHeader({
         className="bg-white"
         placeholder="검색어를 입력해주세요."
       />
-      {mode === 'map' && <SortFilterRow sort={sort} onOpenSort={onOpenSort} />}
+      {mode === 'map' && (
+        <SortFilterRow
+          sort={sort}
+          onOpenSort={onOpenSort}
+          onOpenFilter={onOpenFilter}
+          filterSelected={filterSelected}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/menu/components/preview-card.tsx
+++ b/src/pages/menu/components/preview-card.tsx
@@ -1,0 +1,25 @@
+import ProductCard from '@/pages/main/components/product/product-card';
+import type { Product } from '@/shared/types';
+
+type Props = {
+  product: Product;
+  onClose: () => void;
+};
+
+export default function PreviewCard({ product, onClose }: Props) {
+  return (
+    <div
+      className="absolute right-0 bottom-[3rem] z-[var(--z-bottom-nav)]"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="pointer-events-auto mx-[2rem] mt-auto mb-[8rem] rounded-[1.2rem] bg-white px-[1rem] shadow-[0_0.4rem_2.0rem_rgba(0,0,0,0.16)] ring-1 ring-gray-200"
+      >
+        <div className="p-[1.2rem]">
+          <ProductCard product={product} variant="wide" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/menu/components/sort-filter-row.tsx
+++ b/src/pages/menu/components/sort-filter-row.tsx
@@ -6,10 +6,14 @@ export default function SortFilterRow({
   className = '',
   sort,
   onOpenSort,
+  onOpenFilter,
+  filterSelected,
 }: {
   className?: string;
   sort: SortKey;
   onOpenSort: () => void;
+  onOpenFilter: () => void;
+  filterSelected: boolean;
 }) {
   return (
     <div
@@ -18,7 +22,7 @@ export default function SortFilterRow({
       <Tag selected onClick={onOpenSort}>
         {SORT_LABEL[sort]}
       </Tag>
-      <FilterChip />
+      <FilterChip selected={filterSelected} onClick={onOpenFilter} />
     </div>
   );
 }

--- a/src/pages/menu/components/sort-filter-row.tsx
+++ b/src/pages/menu/components/sort-filter-row.tsx
@@ -1,0 +1,17 @@
+import Tag from '@/shared/components/chips/tag';
+import FilterChip from '@/shared/components/chips/filter-chip';
+
+export default function SortFilterRow({
+  className = '',
+}: {
+  className?: string;
+}) {
+  return (
+    <div
+      className={`mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem] ${className}`}
+    >
+      <Tag selected>인기순</Tag>
+      <FilterChip />
+    </div>
+  );
+}

--- a/src/pages/menu/components/sort-filter-row.tsx
+++ b/src/pages/menu/components/sort-filter-row.tsx
@@ -1,16 +1,23 @@
 import Tag from '@/shared/components/chips/tag';
 import FilterChip from '@/shared/components/chips/filter-chip';
+import { SORT_LABEL, type SortKey } from '@/pages/menu/constants/sort';
 
 export default function SortFilterRow({
   className = '',
+  sort,
+  onOpenSort,
 }: {
   className?: string;
+  sort: SortKey;
+  onOpenSort: () => void;
 }) {
   return (
     <div
       className={`mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem] ${className}`}
     >
-      <Tag selected>인기순</Tag>
+      <Tag selected onClick={onOpenSort}>
+        {SORT_LABEL[sort]}
+      </Tag>
       <FilterChip />
     </div>
   );

--- a/src/pages/menu/components/sort-modal.tsx
+++ b/src/pages/menu/components/sort-modal.tsx
@@ -18,29 +18,40 @@ export default function SortModal({ open, value, onChange, onClose }: Props) {
         className="absolute inset-0 bg-black/40"
         onClick={onClose}
       />
-      <div className="bottom-modal rounded-t-[2.4rem] bg-white">
-        <div className="mx-auto mt-[1.2rem] h-[0.4rem] w-[4rem] rounded-[10px] bg-gray-200" />
-        <h2 className="py-[1.2rem] text-center text-[1.6rem] font-medium">
-          정렬
-        </h2>
-        <ul className="mt-[0.4rem]">
-          {SORT_OPTIONS.map((opt) => (
-            <li key={opt.key}>
-              <button
-                className={cn(
-                  'block w-full cursor-pointer px-[2rem] py-[1.6rem] text-left text-[1.5rem]',
-                  value === opt.key && 'bg-gray-100 font-medium',
-                )}
-                onClick={() => {
-                  onChange(opt.key);
-                  onClose();
-                }}
-              >
-                {opt.label}
-              </button>
-            </li>
-          ))}
-        </ul>
+      <div className="bottom-modal flex-col gap-[0.8rem] rounded-t-[2.4rem] bg-white pt-[1.6rem]">
+        <div className="mx-auto h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
+        <div className="flex-col gap-[1.2rem]">
+          <h2 className="body1 text-center text-black">정렬</h2>
+
+          <ul className="space-y-[0.3rem]">
+            {SORT_OPTIONS.map((opt) => {
+              const selected = value === opt.key;
+              return (
+                <li key={opt.key}>
+                  <button
+                    className={cn(
+                      'block w-full cursor-pointer px-[1.6rem] py-[1.8rem] text-left',
+                      selected && 'bg-gray-100',
+                    )}
+                    onClick={() => {
+                      onChange(opt.key);
+                      onClose();
+                    }}
+                  >
+                    <span
+                      className={cn(
+                        'body3 text-black',
+                        selected && 'font-medium',
+                      )}
+                    >
+                      {opt.label}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/menu/components/sort-modal.tsx
+++ b/src/pages/menu/components/sort-modal.tsx
@@ -1,0 +1,47 @@
+import { SORT_OPTIONS, type SortKey } from '@/pages/menu/constants/sort';
+import { cn } from '@/shared/libs/cn';
+
+type Props = {
+  open: boolean;
+  value: SortKey;
+  onChange: (v: SortKey) => void;
+  onClose: () => void;
+};
+
+export default function SortModal({ open, value, onChange, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[var(--z-bottom-modal)]">
+      <button
+        aria-label="닫기"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+      />
+      <div className="bottom-modal rounded-t-[2.4rem] bg-white">
+        <div className="mx-auto mt-[1.2rem] h-[0.4rem] w-[4rem] rounded-[10px] bg-gray-200" />
+        <h2 className="py-[1.2rem] text-center text-[1.6rem] font-medium">
+          정렬
+        </h2>
+        <ul className="mt-[0.4rem]">
+          {SORT_OPTIONS.map((opt) => (
+            <li key={opt.key}>
+              <button
+                className={cn(
+                  'block w-full cursor-pointer px-[2rem] py-[1.6rem] text-left text-[1.5rem]',
+                  value === opt.key && 'bg-gray-100 font-medium',
+                )}
+                onClick={() => {
+                  onChange(opt.key);
+                  onClose();
+                }}
+              >
+                {opt.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/menu/constants/filter.ts
+++ b/src/pages/menu/constants/filter.ts
@@ -1,0 +1,57 @@
+export type FoodType = 'meal' | 'dessert';
+export type Receive = 'delivery' | 'pickup' | 'now' | 'later';
+
+export type FilterState = {
+  foodType: '' | FoodType;
+  categories: string[];
+  priceMax: '' | '4k' | '6k' | '8k' | '10k' | '12k' | '12kPlus';
+  receive: Receive[];
+};
+
+export const FILTER_DEFAULT: FilterState = {
+  foodType: '',
+  categories: [],
+  priceMax: '',
+  receive: [],
+};
+
+export const FOOD_TYPE_OPTIONS = [
+  { value: 'meal' as const, label: '식사' },
+  { value: 'dessert' as const, label: '디저트' },
+];
+
+export const CATEGORY_OPTIONS = [
+  '일식',
+  '한식',
+  '중식',
+  '양식',
+  '빵',
+  '디저트',
+  '스페인 요리',
+  '멕시코 요리',
+  '패스트 푸드',
+  '건강식',
+  '비건',
+  '할랄',
+  '인도 음식',
+  '직접 입력',
+];
+
+export const PRICE_OPTIONS: {
+  value: FilterState['priceMax'];
+  label: string;
+}[] = [
+  { value: '4k', label: '4,000원 이하' },
+  { value: '6k', label: '6,000원 이하' },
+  { value: '8k', label: '8,000원 이하' },
+  { value: '10k', label: '10,000원 이하' },
+  { value: '12k', label: '12,000원 이하' },
+  { value: '12kPlus', label: '12,000원 이상' },
+];
+
+export const RECEIVE_OPTIONS: { value: Receive; label: string }[] = [
+  { value: 'delivery', label: '배달' },
+  { value: 'pickup', label: '픽업' },
+  { value: 'now', label: '지금 바로' },
+  { value: 'later', label: '나중에' },
+];

--- a/src/pages/menu/constants/menu.ts
+++ b/src/pages/menu/constants/menu.ts
@@ -1,0 +1,7 @@
+export const SOONGSIL_BASE = { lat: 37.4963, lng: 126.9575 } as const;
+
+export const SHEET = {
+  maxHeightRem: 80,
+  minHeightRem: 10,
+  overThresholdRem: 2.4,
+} as const;

--- a/src/pages/menu/constants/sort.ts
+++ b/src/pages/menu/constants/sort.ts
@@ -1,0 +1,15 @@
+export type SortKey = 'popular' | 'priceAsc' | 'priceDesc' | 'distance';
+
+export const SORT_LABEL: Record<SortKey, string> = {
+  popular: '인기순',
+  priceAsc: '가격 낮은 순',
+  priceDesc: '가격 높은 순',
+  distance: '거리순',
+};
+
+export const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'popular', label: SORT_LABEL.popular },
+  { key: 'priceAsc', label: SORT_LABEL.priceAsc },
+  { key: 'priceDesc', label: SORT_LABEL.priceDesc },
+  { key: 'distance', label: SORT_LABEL.distance },
+];

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Product } from '@/shared/types';
+import { SortKey } from '@/pages/menu/constants/sort';
 
 import { useGeolocation } from '@/shared/hooks/use-geolocation';
 import BottomSheet from '@/shared/components/bottom-sheet';
@@ -9,6 +10,7 @@ import ProductCard from '@/pages/main/components/product/product-card';
 import MenuHeader from '@/pages/menu/components/menu-header';
 import MapSection from '@/pages/menu/components/map-section';
 import PreviewCard from '@/pages/menu/components/preview-card';
+import SortModal from '@/pages/menu/components/sort-modal';
 import ListSection from '@/pages/menu/components/list-section';
 
 import { mockPickupProducts, testRestaurants } from '@/shared/mocks';
@@ -25,6 +27,8 @@ export default function MenuPage() {
   const [submitted, setSubmitted] = useState('');
   const [preview, setPreview] = useState<Product | null>(null);
   const [mode, setMode] = useState<'map' | 'list'>('map');
+  const [sort, setSort] = useState<SortKey>('popular');
+  const [sortOpen, setSortOpen] = useState(false);
 
   const navigate = useNavigate();
   const center = loc ?? SOONGSIL_BASE;
@@ -48,6 +52,8 @@ export default function MenuPage() {
         onSubmit={handleSearchSubmit}
         onBack={() => (mode === 'list' ? setMode('map') : navigate(-1))}
         onClear={() => setQuery('')}
+        sort={sort}
+        onOpenSort={() => setSortOpen(true)}
       />
 
       {mode === 'map' ? (
@@ -82,9 +88,18 @@ export default function MenuPage() {
           )}
         </>
       ) : (
-        <ListSection products={products.slice(0, 20)} />
+        <ListSection
+          products={products.slice(0, 20)}
+          sort={sort}
+          onOpenSort={() => setSortOpen(true)}
+        />
       )}
-
+      <SortModal
+        open={sortOpen}
+        value={sort}
+        onChange={setSort}
+        onClose={() => setSortOpen(false)}
+      />
       {error && (
         <div className="absolute top-[1.2rem] left-1/2 -translate-x-1/2 rounded bg-white/90 px-[1.2rem] py-[0.8rem] shadow">
           위치 권한/가져오기 실패: {error.message}

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -7,6 +7,10 @@ import { renderToString } from 'react-dom/server';
 import SearchTextField from '@/shared/components/text-field/search-text-field';
 import BottomSheet from '@/shared/components/bottom-sheet';
 
+// ⬇️ 추가
+import ProductCard from '@/pages/main/components/product/product-card';
+import { mockPickupProducts } from '@/shared/mocks';
+
 export default function MenuPage() {
   const { loc, loading, error, request } = useGeolocation({
     immediate: true,
@@ -93,26 +97,6 @@ export default function MenuPage() {
     [],
   );
 
-  // 바텀시트 임시 데이터(이미 구현 완료되면 제거)
-  const STORES = [
-    {
-      id: 'a1',
-      image: 'https://picsum.photos/seed/a1/960/540',
-      title: '스타벅스 숭실대입구역점',
-      distance: '1.8km',
-      date: '00:00 ~ 17:00',
-      place: '숭실대입구',
-    },
-    {
-      id: 'a2',
-      image: 'https://picsum.photos/seed/a2/960/540',
-      title: '시크릿 런치 밀박스',
-      distance: '1.2km',
-      date: '10:00 ~ 19:00',
-      place: '상도',
-    },
-  ];
-
   return (
     <div className="h-dvh w-full">
       <SearchTextField
@@ -147,42 +131,13 @@ export default function MenuPage() {
       </MapDiv>
 
       <BottomSheet height={80} minHeight={82}>
-        <div className="px-[1.6rem] py-[1.2rem] select-none">
-          <h2 className="text-body1 mb-[1.2rem] font-bold text-black">
-            주변 전시 리스트
-          </h2>
-          {STORES.map((exhibition) => (
-            <div key={exhibition.id} className="mb-[1.6rem]">
-              <img
-                src={exhibition.image}
-                alt={exhibition.title}
-                className="h-[14rem] w-full rounded-[0.6rem] object-cover"
-              />
-              <div className="mt-[0.8rem] flex items-center justify-between">
-                <h3 className="text-body3 font-semibold text-black">
-                  {exhibition.title}
-                </h3>
-                <span className="text-caption2 font-semibold text-red-500">
-                  {exhibition.distance}
-                </span>
-              </div>
-              <div className="text-caption3 mt-[0.6rem] flex items-center justify-between text-gray-500">
-                <p>{exhibition.date}</p>
-                <div className="flex items-center gap-[0.4rem] text-gray-600">
-                  <Icon
-                    name="location"
-                    size={1.6}
-                    className="text-primary"
-                    ariaHidden
-                  />
-                  <span className="cursor-pointer hover:underline">
-                    {exhibition.place}
-                  </span>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+        <section className="mx-auto w-full">
+          <div className="scrollbar-hide flex-col gap-[2.0rem]">
+            {mockPickupProducts.slice(0, 10).map((p) => (
+              <ProductCard key={p.id} product={p} variant="wide" />
+            ))}
+          </div>
+        </section>
       </BottomSheet>
 
       {error && (

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -6,8 +6,9 @@ import Icon from '@/shared/components/icon';
 import { renderToString } from 'react-dom/server';
 import SearchTextField from '@/shared/components/text-field/search-text-field';
 import BottomSheet from '@/shared/components/bottom-sheet';
+import Tag from '@/shared/components/chips/tag';
+import FilterChip from '@/shared/components/chips/filter-chip';
 
-// ⬇️ 추가
 import ProductCard from '@/pages/main/components/product/product-card';
 import { mockPickupProducts } from '@/shared/mocks';
 
@@ -98,22 +99,34 @@ export default function MenuPage() {
   );
 
   return (
-    <div className="h-dvh w-full">
-      <SearchTextField
-        value={query}
-        onChange={setQuery}
-        onSubmit={(v) => setSubmitted(v)}
-        onBack={() => navigate(-1)}
-        onClear={() => setQuery('')}
-        autoFocus={false}
-        showBackButton
-        showSearchIcon
-        className="sticky top-0 z-[var(--z-header)] bg-white"
-        placeholder="검색어를 입력해주세요."
-      />
+    <div className="relative h-[100dvh] w-full overflow-hidden">
+      <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
+        <SearchTextField
+          value={query}
+          onChange={setQuery}
+          onSubmit={(v) => setSubmitted(v)}
+          onBack={() => navigate(-1)}
+          onClear={() => setQuery('')}
+          autoFocus={false}
+          showBackButton
+          showSearchIcon
+          className="bg-white"
+          placeholder="검색어를 입력해주세요."
+        />
+
+        <div className="mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem]">
+          <Tag selected>인기순</Tag>
+          <FilterChip />
+        </div>
+      </div>
 
       <MapDiv
-        style={{ width: '100%', height: '100dvh' }}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+        }}
         fallback={
           <div className="grid h-full place-items-center">지도 로딩 중…</div>
         }

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Product } from '@/shared/types';
 
@@ -31,13 +31,21 @@ export default function MenuPage() {
 
   const products = useMemo(() => mockPickupProducts, []);
 
+  const handleSearchSubmit = useCallback(
+    (v: string) => {
+      setQuery(v);
+      setSubmitted(v);
+      navigate(`/search?q=${encodeURIComponent(v)}`);
+    },
+    [navigate],
+  );
   return (
     <div className="relative h-[100dvh] w-full overflow-hidden">
       <MenuHeader
         mode={mode}
         query={query}
         setQuery={setQuery}
-        onSubmit={setSubmitted}
+        onSubmit={handleSearchSubmit}
         onBack={() => (mode === 'list' ? setMode('map') : navigate(-1))}
         onClear={() => setQuery('')}
       />

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -1,12 +1,18 @@
 import { useMemo, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Product } from '@/shared/types';
+import { hasActiveFilters } from '@/pages/menu/utils/has-active-filters';
+import {
+  FILTER_DEFAULT,
+  type FilterState,
+} from '@/pages/menu/constants/filter';
 import { SortKey } from '@/pages/menu/constants/sort';
 
 import { useGeolocation } from '@/shared/hooks/use-geolocation';
 import BottomSheet from '@/shared/components/bottom-sheet';
 
 import ProductCard from '@/pages/main/components/product/product-card';
+import FilterModal from './components/filter-modal';
 import MenuHeader from '@/pages/menu/components/menu-header';
 import MapSection from '@/pages/menu/components/map-section';
 import PreviewCard from '@/pages/menu/components/preview-card';
@@ -29,7 +35,10 @@ export default function MenuPage() {
   const [mode, setMode] = useState<'map' | 'list'>('map');
   const [sort, setSort] = useState<SortKey>('popular');
   const [sortOpen, setSortOpen] = useState(false);
+  const [filter, setFilter] = useState<FilterState>(FILTER_DEFAULT);
+  const [filterOpen, setFilterOpen] = useState(false);
 
+  const filterSelected = hasActiveFilters(filter);
   const navigate = useNavigate();
   const center = loc ?? SOONGSIL_BASE;
 
@@ -54,8 +63,9 @@ export default function MenuPage() {
         onClear={() => setQuery('')}
         sort={sort}
         onOpenSort={() => setSortOpen(true)}
+        onOpenFilter={() => setFilterOpen(true)}
+        filterSelected={filterSelected}
       />
-
       {mode === 'map' ? (
         <>
           <MapSection
@@ -92,14 +102,25 @@ export default function MenuPage() {
           products={products.slice(0, 20)}
           sort={sort}
           onOpenSort={() => setSortOpen(true)}
+          onOpenFilter={() => setFilterOpen(true)}
+          filterSelected={filterSelected}
         />
       )}
+
       <SortModal
         open={sortOpen}
         value={sort}
         onChange={setSort}
         onClose={() => setSortOpen(false)}
       />
+
+      <FilterModal
+        open={filterOpen}
+        value={filter}
+        onApply={(next) => setFilter(next)}
+        onClose={() => setFilterOpen(false)}
+      />
+
       {error && (
         <div className="absolute top-[1.2rem] left-1/2 -translate-x-1/2 rounded bg-white/90 px-[1.2rem] py-[0.8rem] shadow">
           위치 권한/가져오기 실패: {error.message}

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -1,16 +1,18 @@
-import { useMemo, useState, useRef, useEffect } from 'react';
-import { Container as MapDiv, NaverMap, Marker } from 'react-naver-maps';
-import { useGeolocation } from '@/shared/hooks/use-geolocation';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import Icon from '@/shared/components/icon';
-import { renderToString } from 'react-dom/server';
-import SearchTextField from '@/shared/components/text-field/search-text-field';
-import BottomSheet from '@/shared/components/bottom-sheet';
-import Tag from '@/shared/components/chips/tag';
-import FilterChip from '@/shared/components/chips/filter-chip';
-import ProductCard from '@/pages/main/components/product/product-card';
 import type { Product } from '@/shared/types';
+
+import { useGeolocation } from '@/shared/hooks/use-geolocation';
+import BottomSheet from '@/shared/components/bottom-sheet';
+
+import ProductCard from '@/pages/main/components/product/product-card';
+import MenuHeader from '@/pages/menu/components/menu-header';
+import MapSection from '@/pages/menu/components/map-section';
+import PreviewCard from '@/pages/menu/components/preview-card';
+import ListSection from '@/pages/menu/components/list-section';
+
 import { mockPickupProducts, testRestaurants } from '@/shared/mocks';
+import { SOONGSIL_BASE, SHEET } from '@/pages/menu/constants/menu';
 
 export default function MenuPage() {
   const { loc, loading, error, request } = useGeolocation({
@@ -22,164 +24,49 @@ export default function MenuPage() {
   const [query, setQuery] = useState('');
   const [submitted, setSubmitted] = useState('');
   const [preview, setPreview] = useState<Product | null>(null);
-
   const [mode, setMode] = useState<'map' | 'list'>('map');
 
-  const soongsilBase = { lat: 37.4963, lng: 126.9575 };
-  const center = loc ?? soongsilBase;
-  const mapRef = useRef<any>(null);
   const navigate = useNavigate();
+  const center = loc ?? SOONGSIL_BASE;
 
-  const myMarkerIcon = useMemo(
-    () => ({
-      content: renderToString(
-        <div style={{ transform: 'translate(-50%, -100%)' }}>
-          <Icon
-            name="location"
-            size={2.4}
-            className="text-primary"
-            ariaHidden
-          />
-        </div>,
-      ),
-    }),
-    [],
-  );
-
-  const getMapInstance = (ref: any) => ref?.instance ?? ref?.map ?? ref ?? null;
-  const [mapInstance, setMapInstance] = useState<any>(null);
-
-  const handleMapRef = (node: any) => {
-    mapRef.current = node;
-    const inst = getMapInstance(node);
-    if (inst) setMapInstance(inst);
-  };
-
-  useEffect(() => {
-    const n = (window as any).naver;
-    if (!n?.maps || !mapInstance) return;
-
-    const off: any[] = [];
-    off.push(
-      n.maps.Event.addListener(mapInstance, 'click', () => setPreview(null)),
-    );
-    off.push(
-      n.maps.Event.addListener(mapInstance, 'tap', () => setPreview(null)),
-    );
-
-    return () => off.forEach((h) => n.maps.Event.removeListener(h));
-  }, [mapInstance]);
-
-  const restaurantMarkerIcon = useMemo(
-    () => ({
-      content: renderToString(
-        <div style={{ transform: 'translate(-50%, -100%)' }}>
-          <Icon
-            name="location"
-            size={2.4}
-            className="text-primary"
-            ariaHidden
-          />
-        </div>,
-      ),
-    }),
-    [],
-  );
-  function SortFilterRow({ className = '' }: { className?: string }) {
-    return (
-      <div
-        className={`mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem] ${className}`}
-      >
-        <Tag selected>인기순</Tag>
-        <FilterChip />
-      </div>
-    );
-  }
-  const Header = (
-    <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
-      <SearchTextField
-        value={query}
-        onChange={setQuery}
-        onSubmit={(v) => setSubmitted(v)}
-        onBack={() => (mode === 'list' ? setMode('map') : navigate(-1))}
-        onClear={() => setQuery('')}
-        autoFocus={false}
-        showBackButton
-        showSearchIcon
-        className="bg-white"
-        placeholder="검색어를 입력해주세요."
-      />
-      {mode === 'map' && <SortFilterRow />}
-    </div>
-  );
+  const products = useMemo(() => mockPickupProducts, []);
 
   return (
     <div className="relative h-[100dvh] w-full overflow-hidden">
-      <div>{Header}</div>
+      <MenuHeader
+        mode={mode}
+        query={query}
+        setQuery={setQuery}
+        onSubmit={setSubmitted}
+        onBack={() => (mode === 'list' ? setMode('map') : navigate(-1))}
+        onClear={() => setQuery('')}
+      />
 
       {mode === 'map' ? (
         <>
-          <MapDiv
-            style={{
-              position: 'absolute',
-              inset: 0,
-              width: '100%',
-              height: '100%',
-            }}
-            fallback={
-              <div className="grid h-full place-items-center">
-                지도 로딩 중…
-              </div>
-            }
-          >
-            <NaverMap
-              defaultCenter={soongsilBase}
-              center={center}
-              defaultZoom={16}
-              ref={handleMapRef}
-            >
-              <Marker position={center} icon={myMarkerIcon as any} />
-              {testRestaurants.map((p, idx) => (
-                <Marker
-                  key={p.id}
-                  position={{ lat: p.lat, lng: p.lng }}
-                  icon={restaurantMarkerIcon as any}
-                  onClick={() =>
-                    setPreview(
-                      mockPickupProducts[idx % mockPickupProducts.length],
-                    )
-                  }
-                />
-              ))}
-            </NaverMap>
-          </MapDiv>
+          <MapSection
+            center={center}
+            defaultCenter={SOONGSIL_BASE}
+            restaurants={testRestaurants}
+            products={products}
+            onPickPreview={(p) => setPreview(p)}
+            onMapTap={() => setPreview(null)}
+          />
 
-          {preview && (
-            <div
-              className="absolute right-0 bottom-[3rem] z-[var(--z-bottom-nav)]"
-              onClick={() => setPreview(null)}
-            >
-              <div
-                onClick={(e) => e.stopPropagation()}
-                className="pointer-events-auto mx-[2rem] mt-auto mb-[8rem] rounded-[1.2rem] bg-white px-[1rem] shadow-[0_0.4rem_2.0rem_rgba(0,0,0,0.16)] ring-1 ring-gray-200"
-              >
-                <div className="p-[1.2rem]">
-                  <ProductCard product={preview} variant="wide" />
-                </div>
-              </div>
-            </div>
-          )}
-
-          {!preview && (
+          {preview ? (
+            <PreviewCard product={preview} onClose={() => setPreview(null)} />
+          ) : (
             <BottomSheet
-              maxHeightRem={80}
-              minHeightRem={10}
+              maxHeightRem={SHEET.maxHeightRem}
+              minHeightRem={SHEET.minHeightRem}
               onOverExpand={() => setMode('list')}
             >
               <section className="mx-auto w-full">
                 <div className="flex-col gap-[2.0rem]">
-                  {mockPickupProducts.slice(0, 10).map((p) => (
-                    <ProductCard key={p.id} product={p} variant="wide" />
+                  {products.slice(0, 10).map((p) => (
+                    <div key={p.id}>
+                      <ProductCard product={p} variant="wide" />
+                    </div>
                   ))}
                 </div>
               </section>
@@ -187,16 +74,7 @@ export default function MenuPage() {
           )}
         </>
       ) : (
-        <div className="scrollbar-hide relative h-[100dvh] w-full flex-col gap-[1.2rem] overflow-y-auto pt-[5rem] pb-[6rem]">
-          <SortFilterRow />
-          <div className="px-[2rem] pb-[4rem]">
-            <div className="flex-col gap-[2.0rem]">
-              {mockPickupProducts.slice(0, 20).map((p) => (
-                <ProductCard key={p.id} product={p} variant="wide" />
-              ))}
-            </div>
-          </div>
-        </div>
+        <ListSection products={products.slice(0, 20)} />
       )}
 
       {error && (

--- a/src/pages/menu/menu-page.tsx
+++ b/src/pages/menu/menu-page.tsx
@@ -85,7 +85,16 @@ export default function MenuPage() {
     }),
     [],
   );
-
+  function SortFilterRow({ className = '' }: { className?: string }) {
+    return (
+      <div
+        className={`mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem] ${className}`}
+      >
+        <Tag selected>인기순</Tag>
+        <FilterChip />
+      </div>
+    );
+  }
   const Header = (
     <div className="absolute top-0 right-0 left-0 z-[var(--z-header)]">
       <SearchTextField
@@ -100,10 +109,7 @@ export default function MenuPage() {
         className="bg-white"
         placeholder="검색어를 입력해주세요."
       />
-      <div className="mt-[1.2rem] flex items-center gap-[0.8rem] px-[2rem]">
-        <Tag selected>인기순</Tag>
-        <FilterChip />
-      </div>
+      {mode === 'map' && <SortFilterRow />}
     </div>
   );
 
@@ -181,8 +187,8 @@ export default function MenuPage() {
           )}
         </>
       ) : (
-        <div className="scrollbar-hide relative h-[100dvh] w-full overflow-y-auto pb-[6rem]">
-          <div className="pt-[11rem]" />
+        <div className="scrollbar-hide relative h-[100dvh] w-full flex-col gap-[1.2rem] overflow-y-auto pt-[5rem] pb-[6rem]">
+          <SortFilterRow />
           <div className="px-[2rem] pb-[4rem]">
             <div className="flex-col gap-[2.0rem]">
               {mockPickupProducts.slice(0, 20).map((p) => (

--- a/src/pages/menu/menu.tsx
+++ b/src/pages/menu/menu.tsx
@@ -1,5 +1,202 @@
+import { useMemo, useState } from 'react';
+import { Container as MapDiv, NaverMap, Marker } from 'react-naver-maps';
+import { useGeolocation } from '@/shared/hooks/use-geolocation';
+import { useNavigate } from 'react-router-dom';
+import Icon from '@/shared/components/icon';
+import { renderToString } from 'react-dom/server';
+import SearchTextField from '@/shared/components/text-field/search-text-field';
+import BottomSheet from '@/shared/components/bottom-sheet';
+
 export default function MenuPage() {
+  const { loc, loading, error, request } = useGeolocation({
+    immediate: true,
+    watch: false,
+    options: { enableHighAccuracy: true, timeout: 8000, maximumAge: 30_000 },
+  });
+
+  const [query, setQuery] = useState('');
+  const [submitted, setSubmitted] = useState('');
+
+  const soongsilBase = { lat: 37.4963, lng: 126.9575 };
+  const center = loc ?? soongsilBase;
+
+  const navigate = useNavigate();
+
+  const testRestaurants = [
+    {
+      id: 1,
+      name: '정문돈까스',
+      lat: soongsilBase.lat + 0.0018,
+      lng: soongsilBase.lng - 0.0012,
+    },
+    {
+      id: 2,
+      name: '상도라멘',
+      lat: soongsilBase.lat + 0.001,
+      lng: soongsilBase.lng + 0.001,
+    },
+    {
+      id: 3,
+      name: '숭실카레집',
+      lat: soongsilBase.lat - 0.0012,
+      lng: soongsilBase.lng + 0.0008,
+    },
+    {
+      id: 4,
+      name: '상도불백',
+      lat: soongsilBase.lat - 0.0018,
+      lng: soongsilBase.lng - 0.001,
+    },
+    {
+      id: 5,
+      name: '홍콩반점 숭실',
+      lat: soongsilBase.lat + 0.0006,
+      lng: soongsilBase.lng - 0.0015,
+    },
+    {
+      id: 6,
+      name: '밥버거 숭실',
+      lat: soongsilBase.lat - 0.0005,
+      lng: soongsilBase.lng + 0.0016,
+    },
+  ];
+
+  const myMarkerIcon = useMemo(
+    () => ({
+      content: renderToString(
+        <div style={{ transform: 'translate(-50%, -100%)' }}>
+          <Icon
+            name="location"
+            size={2.4}
+            className="text-primary"
+            ariaHidden
+          />
+        </div>,
+      ),
+    }),
+    [],
+  );
+
+  const restaurantMarkerIcon = useMemo(
+    () => ({
+      content: renderToString(
+        <div style={{ transform: 'translate(-50%, -100%)' }}>
+          <Icon
+            name="location"
+            size={2.4}
+            className="text-primary"
+            ariaHidden
+          />
+        </div>,
+      ),
+    }),
+    [],
+  );
+
+  // 바텀시트 임시 데이터(이미 구현 완료되면 제거)
+  const STORES = [
+    {
+      id: 'a1',
+      image: 'https://picsum.photos/seed/a1/960/540',
+      title: '스타벅스 숭실대입구역점',
+      distance: '1.8km',
+      date: '00:00 ~ 17:00',
+      place: '숭실대입구',
+    },
+    {
+      id: 'a2',
+      image: 'https://picsum.photos/seed/a2/960/540',
+      title: '시크릿 런치 밀박스',
+      distance: '1.2km',
+      date: '10:00 ~ 19:00',
+      place: '상도',
+    },
+  ];
+
   return (
-    <div className="flex-col-between min-h-[100dvh] bg-white">메뉴 페이지</div>
+    <div className="h-dvh w-full">
+      <SearchTextField
+        value={query}
+        onChange={setQuery}
+        onSubmit={(v) => setSubmitted(v)}
+        onBack={() => navigate(-1)}
+        onClear={() => setQuery('')}
+        autoFocus={false}
+        showBackButton
+        showSearchIcon
+        className="sticky top-0 z-[var(--z-header)] bg-white"
+        placeholder="검색어를 입력해주세요."
+      />
+
+      <MapDiv
+        style={{ width: '100%', height: '100dvh' }}
+        fallback={
+          <div className="grid h-full place-items-center">지도 로딩 중…</div>
+        }
+      >
+        <NaverMap defaultCenter={soongsilBase} center={center} defaultZoom={16}>
+          <Marker position={center} icon={myMarkerIcon as any} />
+          {testRestaurants.map((p) => (
+            <Marker
+              key={p.id}
+              position={{ lat: p.lat, lng: p.lng }}
+              icon={restaurantMarkerIcon as any}
+            />
+          ))}
+        </NaverMap>
+      </MapDiv>
+
+      <BottomSheet height={80} minHeight={82}>
+        <div className="px-[1.6rem] py-[1.2rem] select-none">
+          <h2 className="text-body1 mb-[1.2rem] font-bold text-black">
+            주변 전시 리스트
+          </h2>
+          {STORES.map((exhibition) => (
+            <div key={exhibition.id} className="mb-[1.6rem]">
+              <img
+                src={exhibition.image}
+                alt={exhibition.title}
+                className="h-[14rem] w-full rounded-[0.6rem] object-cover"
+              />
+              <div className="mt-[0.8rem] flex items-center justify-between">
+                <h3 className="text-body3 font-semibold text-black">
+                  {exhibition.title}
+                </h3>
+                <span className="text-caption2 font-semibold text-red-500">
+                  {exhibition.distance}
+                </span>
+              </div>
+              <div className="text-caption3 mt-[0.6rem] flex items-center justify-between text-gray-500">
+                <p>{exhibition.date}</p>
+                <div className="flex items-center gap-[0.4rem] text-gray-600">
+                  <Icon
+                    name="location"
+                    size={1.6}
+                    className="text-primary"
+                    ariaHidden
+                  />
+                  <span className="cursor-pointer hover:underline">
+                    {exhibition.place}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </BottomSheet>
+
+      {error && (
+        <div className="absolute top-[1.2rem] left-1/2 -translate-x-1/2 rounded bg-white/90 px-[1.2rem] py-[0.8rem] shadow">
+          위치 권한/가져오기 실패: {error.message}
+          <button
+            className="ml-[0.8rem] underline"
+            onClick={request}
+            disabled={loading}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/pages/menu/utils/has-active-filters.ts
+++ b/src/pages/menu/utils/has-active-filters.ts
@@ -1,0 +1,7 @@
+import type { FilterState } from '@/pages/menu/constants/filter';
+
+export function hasActiveFilters(f: FilterState) {
+  return Boolean(
+    f.foodType || f.priceMax || f.categories.length || f.receive.length,
+  );
+}

--- a/src/pages/menu/utils/make-pin.tsx
+++ b/src/pages/menu/utils/make-pin.tsx
@@ -1,0 +1,12 @@
+import { renderToString } from 'react-dom/server';
+import Icon from '@/shared/components/icon';
+
+export function makeLocationPinHtml(className = 'text-primary') {
+  return {
+    content: renderToString(
+      <div style={{ transform: 'translate(-50%, -100%)' }}>
+        <Icon name="location" size={2.4} className={className} ariaHidden />
+      </div>,
+    ),
+  };
+}

--- a/src/pages/menu/utils/naver-map.ts
+++ b/src/pages/menu/utils/naver-map.ts
@@ -1,0 +1,2 @@
+export const getMapInstance = (ref: any) =>
+  ref?.instance ?? ref?.map ?? ref ?? null;

--- a/src/pages/recommend/components/stepper-dot.tsx
+++ b/src/pages/recommend/components/stepper-dot.tsx
@@ -23,7 +23,7 @@ export default function StepDot({
   const number = index + 1;
 
   return (
-    <div className="text-caption1 flex-col-center">
+    <div className="caption1 flex-col-center">
       <div
         className={cn(
           'grid place-items-center rounded-full',
@@ -33,16 +33,12 @@ export default function StepDot({
         aria-current={isCurrent ? 'step' : undefined}
         aria-label={`${number} ${isDone ? doneLabel : stepLabel}`}
       >
-        {isDone ? (
-          <CheckIcon />
-        ) : (
-          <span className="text-caption1">{number}</span>
-        )}
+        {isDone ? <CheckIcon /> : <span className="caption1">{number}</span>}
       </div>
 
       <span
         className={cn(
-          'text-caption1 mt-[0.8rem]',
+          'caption1 mt-[0.8rem]',
           isDone ? STEPPER_COLOR.label.dim : STEPPER_COLOR.label.default,
         )}
       >

--- a/src/pages/recommend/steps/recommend-loading.tsx
+++ b/src/pages/recommend/steps/recommend-loading.tsx
@@ -8,7 +8,7 @@ export default function RecommendLoading({ visible }: Props) {
         <div className="h-[0.8rem] w-full overflow-hidden rounded-full bg-gray-100">
           <div className="h-full w-[40%] animate-[loading_1.2s_ease-in-out_infinite] rounded-full bg-gray-900" />
         </div>
-        <p className="text-body1 text-center text-black">
+        <p className="body1 text-center text-black">
           AI가 주문 기록을 바탕으로
           <br />
           000님이 좋아하실 만한

--- a/src/pages/recommend/steps/step1-categories.tsx
+++ b/src/pages/recommend/steps/step1-categories.tsx
@@ -12,9 +12,7 @@ type Props = {
 export default function Step1Categories({ selected, onToggle }: Props) {
   return (
     <div className="flex-col gap-[1.2rem] px-[2rem]">
-      <h2 className="text-head3 text-black">
-        닉네임님, 오늘은 어떤 음식이 땡겨요?
-      </h2>
+      <h2 className="head3 text-black">닉네임님, 오늘은 어떤 음식이 땡겨요?</h2>
 
       <div className="flex flex-wrap gap-x-[1rem] gap-y-[1.2rem] pr-[0.5rem]">
         {FOOD_OPTIONS.map((opt) => (

--- a/src/pages/recommend/steps/step2-budget.tsx
+++ b/src/pages/recommend/steps/step2-budget.tsx
@@ -11,7 +11,7 @@ export default function Step2Budget({ value, onChange }: Props) {
   const onInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const onlyDigits = e.target.value.replace(/[^\d]/g, '');
-      onChange(onlyDigits === '' ? '' : Number(onlyDigits)); // ⬅️ clamp 제거
+      onChange(onlyDigits === '' ? '' : Number(onlyDigits));
     },
     [onChange],
   );
@@ -24,31 +24,31 @@ export default function Step2Budget({ value, onChange }: Props) {
 
   return (
     <div className="flex-col gap-[4rem] px-[2rem]">
-      <h2 className="text-head3">원하시는 가격대를 입력해주세요</h2>
+      <h2 className="head3">원하시는 가격대를 입력해주세요</h2>
 
       <div className="flex-col-center gap-[1.1rem] px-[2.0rem]">
         <div className="flex h-[2.8rem] items-center gap-[1.5rem]">
-          <span className="text-body1 text-gray-600">최대</span>
+          <span className="body1 text-gray-600">최대</span>
           <div className="flex-row gap-[1.4rem]">
             <div className="relative max-w-[16rem] flex-1">
               <input
                 aria-label="최대 가격"
                 inputMode="numeric"
                 pattern="[0-9]*"
-                className="peer text-body1 h-[2.8rem] w-full border-0 border-b-[0.2rem] border-black bg-transparent pb-[0.6rem] tracking-[-0.03em] outline-none focus:border-gray-900"
+                className="peer body1 h-[2.8rem] w-full border-0 border-b-[0.2rem] border-black bg-transparent pb-[0.6rem] tracking-[-0.03em] outline-none focus:border-gray-900"
                 value={value === '' ? '' : formatKRW(value)}
                 onChange={onInput}
                 onBlur={onBlur}
               />
             </div>
 
-            <span className="text-head3 text-black">원</span>
+            <span className="head3 text-black">원</span>
           </div>
         </div>
 
         <button
           type="button"
-          className="text-caption2 mx-auto cursor-pointer text-gray-600 underline underline-offset-[0.2rem]"
+          className="caption2 mx-auto cursor-pointer text-gray-600 underline underline-offset-[0.2rem]"
         >
           가격은 상관 없어요
         </button>

--- a/src/pages/recommend/steps/step3-method.tsx
+++ b/src/pages/recommend/steps/step3-method.tsx
@@ -26,7 +26,7 @@ export default function Step3Method({ value, onChange }: Props) {
   };
   return (
     <div className="flex-col gap-[1.2rem] px-[2.0rem]">
-      <h2 className="text-head3 text-black">
+      <h2 className="head3 text-black">
         원하시는 상품 수령 방법을 선택해주세요
       </h2>
 
@@ -35,7 +35,7 @@ export default function Step3Method({ value, onChange }: Props) {
         value={value}
         onChange={handleChange}
         options={options}
-        className="text-body3"
+        className="body3"
       />
 
       {showError && (

--- a/src/shared/components/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet.tsx
@@ -76,15 +76,15 @@ export default function BottomSheet({
     <div
       ref={sheetRef}
       onPointerDown={handlePointerDown}
-      className="fixed bottom-4 left-1/2 z-10 w-full max-w-[43rem] touch-none rounded-t-[3rem] bg-white shadow-lg transition-transform duration-300"
+      className="bottom-sheet w-full touch-none rounded-t-[3rem] bg-white px-[2rem] pt-[1.4rem] pb-[6.5rem] shadow-lg transition-transform duration-300"
       style={{
         transform: `translate(-50%, ${translateY}px)`,
         height: `${sheetHeight}px`,
         touchAction: 'none',
       }}
     >
-      <div className="mx-auto my-3 h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
-      <div className="max-h-[calc(100%-40px)] overflow-y-auto px-4">
+      <div className="mx-auto mb-[1.4rem] h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
+      <div className="scrollbar-hide max-h-[calc(100%-40px)] overflow-y-auto px-4">
         {children}
       </div>
     </div>

--- a/src/shared/components/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet.tsx
@@ -1,0 +1,92 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+type BottomSheetProps = {
+  children: React.ReactNode;
+  height?: number;
+  minHeight?: number;
+};
+
+export default function BottomSheet({
+  children,
+  height = 80,
+  minHeight = 70,
+}: BottomSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const [sheetHeight, setSheetHeight] = useState<number>(0);
+  const [translateY, setTranslateY] = useState<number>(0);
+  const translateYRef = useRef(0);
+  const [dragStartY, setDragStartY] = useState<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    const vh = window.innerHeight;
+    const calculatedHeight = (vh * height) / 100;
+    const initialTranslateY = calculatedHeight - minHeight;
+    setSheetHeight(calculatedHeight);
+    setTranslateY(initialTranslateY);
+    translateYRef.current = initialTranslateY;
+  }, [height, minHeight]);
+
+  useEffect(() => {
+    translateYRef.current = translateY;
+  }, [translateY]);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    setDragStartY(e.clientY);
+    setIsDragging(true);
+  };
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!isDragging || dragStartY === null) return;
+      const delta = e.clientY - dragStartY;
+      const newY = Math.min(
+        Math.max(translateYRef.current + delta, 0),
+        sheetHeight - minHeight,
+      );
+      setTranslateY(newY);
+      translateYRef.current = newY;
+      setDragStartY(e.clientY);
+    },
+    [isDragging, dragStartY, sheetHeight, minHeight],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    const threshold = (sheetHeight - minHeight) / 2;
+    setTranslateY((prev) => (prev < threshold ? 0 : sheetHeight - minHeight));
+  }, [isDragging, sheetHeight, minHeight]);
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', handlePointerUp);
+    } else {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    }
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isDragging, handlePointerMove, handlePointerUp]);
+
+  return (
+    <div
+      ref={sheetRef}
+      onPointerDown={handlePointerDown}
+      className="fixed bottom-4 left-1/2 z-10 w-full max-w-[43rem] touch-none rounded-t-[3rem] bg-white shadow-lg transition-transform duration-300"
+      style={{
+        transform: `translate(-50%, ${translateY}px)`,
+        height: `${sheetHeight}px`,
+        touchAction: 'none',
+      }}
+    >
+      <div className="mx-auto my-3 h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
+      <div className="max-h-[calc(100%-40px)] overflow-y-auto px-4">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet.tsx
@@ -2,65 +2,152 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 
 type BottomSheetProps = {
   children: React.ReactNode;
-  height?: number;
+  /** 최대 높이(rem). 기본 80rem */
+  maxHeightRem?: number;
+  /** 접힌 상태에서 보이는 높이(rem). 기본 9rem */
+  minHeightRem?: number;
+  /** 과거 호환: 접힌 높이 px 단위 */
   minHeight?: number;
+  /** 높이 % of viewport (과거 호환). 기본 80 */
+  height?: number;
+  /** 최상단에서 추가로 위로 당길 때 호출 (리스트 전환 등에 사용) */
+  onOverExpand?: () => void;
+  /** 오버드래그 임계치(rem). 기본 2.4rem */
+  overThresholdRem?: number;
+  /** 상단 드래그 허용 영역 높이(rem). 기본 4rem */
+  dragAreaRem?: number;
 };
 
 export default function BottomSheet({
   children,
+  maxHeightRem = 80,
+  minHeightRem = 10,
+  minHeight,
   height = 80,
-  minHeight = 70,
+  onOverExpand,
+  overThresholdRem = 2.4,
+  dragAreaRem = 4,
 }: BottomSheetProps) {
   const sheetRef = useRef<HTMLDivElement>(null);
-  const [sheetHeight, setSheetHeight] = useState<number>(0);
-  const [translateY, setTranslateY] = useState<number>(0);
+
+  const [sheetHeight, setSheetHeight] = useState(0);
+  const [translateY, setTranslateY] = useState(0);
   const translateYRef = useRef(0);
-  const [dragStartY, setDragStartY] = useState<number | null>(null);
+
   const [isDragging, setIsDragging] = useState(false);
+  const dragEnabledRef = useRef(false);
+  const lastClientYRef = useRef<number | null>(null);
+  const overPullUpRef = useRef(0);
+
+  const remToPx = useCallback((rem: number) => {
+    const base = parseFloat(
+      getComputedStyle(document.documentElement).fontSize || '10px',
+    );
+    return rem * base;
+  }, []);
+
+  const getMinVisiblePx = useCallback(() => {
+    return minHeight != null ? minHeight : remToPx(minHeightRem);
+  }, [minHeight, minHeightRem, remToPx]);
 
   useEffect(() => {
     const vh = window.innerHeight;
-    const calculatedHeight = (vh * height) / 100;
-    const initialTranslateY = calculatedHeight - minHeight;
+    const maxPx = remToPx(maxHeightRem);
+    const percentPx = (vh * height) / 100;
+
+    const calculatedHeight = Math.min(vh, maxPx, percentPx);
+    const minVisiblePx = getMinVisiblePx();
+    const initialTranslateY = Math.max(calculatedHeight - minVisiblePx, 0);
+
     setSheetHeight(calculatedHeight);
     setTranslateY(initialTranslateY);
     translateYRef.current = initialTranslateY;
-  }, [height, minHeight]);
+  }, [height, maxHeightRem, minHeightRem, remToPx, getMinVisiblePx]);
 
   useEffect(() => {
     translateYRef.current = translateY;
   }, [translateY]);
 
-  const handlePointerDown = (e: React.PointerEvent) => {
-    setDragStartY(e.clientY);
-    setIsDragging(true);
+  const startDragIfInDragZone = (e: React.PointerEvent) => {
+    if (!sheetRef.current) return;
+
+    const target = e.target as HTMLElement;
+    const isHandle = target?.dataset?.dragHandle === 'true';
+
+    const rect = sheetRef.current.getBoundingClientRect();
+    const yInSheet = e.clientY - rect.top;
+    const dragZone = remToPx(dragAreaRem);
+
+    if (isHandle || yInSheet <= dragZone) {
+      dragEnabledRef.current = true;
+      setIsDragging(true);
+      lastClientYRef.current = e.clientY;
+      overPullUpRef.current = 0;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      e.preventDefault();
+    } else {
+      dragEnabledRef.current = false;
+    }
   };
 
   const handlePointerMove = useCallback(
     (e: PointerEvent) => {
-      if (!isDragging || dragStartY === null) return;
-      const delta = e.clientY - dragStartY;
-      const newY = Math.min(
-        Math.max(translateYRef.current + delta, 0),
-        sheetHeight - minHeight,
-      );
-      setTranslateY(newY);
-      translateYRef.current = newY;
-      setDragStartY(e.clientY);
+      if (!isDragging || !dragEnabledRef.current) return;
+      if (lastClientYRef.current == null) {
+        lastClientYRef.current = e.clientY;
+        return;
+      }
+
+      const delta = e.clientY - lastClientYRef.current;
+      let next = translateYRef.current + delta;
+
+      if (next < 0) {
+        overPullUpRef.current += -next;
+        next = 0;
+      }
+
+      const bottom = Math.max(sheetHeight - getMinVisiblePx(), 0);
+      if (next > bottom) next = bottom;
+
+      setTranslateY(next);
+      translateYRef.current = next;
+      lastClientYRef.current = e.clientY;
     },
-    [isDragging, dragStartY, sheetHeight, minHeight],
+    [isDragging, sheetHeight, getMinVisiblePx],
   );
 
   const handlePointerUp = useCallback(() => {
     if (!isDragging) return;
+
     setIsDragging(false);
-    const threshold = (sheetHeight - minHeight) / 2;
-    setTranslateY((prev) => (prev < threshold ? 0 : sheetHeight - minHeight));
-  }, [isDragging, sheetHeight, minHeight]);
+    dragEnabledRef.current = false;
+
+    const bottom = Math.max(sheetHeight - getMinVisiblePx(), 0);
+    const threshold = bottom / 2;
+
+    setTranslateY((prev) => (prev < threshold ? 0 : bottom));
+
+    const overThresholdPx = remToPx(overThresholdRem);
+    if (overPullUpRef.current >= overThresholdPx && onOverExpand) {
+      onOverExpand();
+    }
+
+    overPullUpRef.current = 0;
+    lastClientYRef.current = null;
+  }, [
+    isDragging,
+    sheetHeight,
+    getMinVisiblePx,
+    onOverExpand,
+    overThresholdRem,
+    remToPx,
+  ]);
 
   useEffect(() => {
     if (isDragging) {
-      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointermove', handlePointerMove, {
+        passive: false,
+      });
       window.addEventListener('pointerup', handlePointerUp);
     } else {
       window.removeEventListener('pointermove', handlePointerMove);
@@ -75,16 +162,21 @@ export default function BottomSheet({
   return (
     <div
       ref={sheetRef}
-      onPointerDown={handlePointerDown}
-      className="bottom-sheet w-full touch-none rounded-t-[3rem] bg-white px-[2rem] pt-[1.4rem] pb-[6.5rem] shadow-lg transition-transform duration-300"
+      onPointerDown={startDragIfInDragZone}
+      className="fixed bottom-0 left-1/2 z-[var(--z-bottom-nav)] w-full max-w-[var(--max-width)] rounded-t-[3rem] bg-white px-[2rem] pt-[1.4rem] pb-[6.5rem] shadow-lg"
       style={{
-        transform: `translate(-50%, ${translateY}px)`,
+        transform: `translateX(-50%) translateY(${translateY}px)`,
         height: `${sheetHeight}px`,
         touchAction: 'none',
+        pointerEvents: 'auto',
       }}
     >
-      <div className="mx-auto mb-[1.4rem] h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
-      <div className="scrollbar-hide max-h-[calc(100%-40px)] overflow-y-auto px-4">
+      <div
+        data-drag-handle="true"
+        className="mx-auto mb-[1.4rem] h-[0.3rem] w-[5rem] cursor-grab rounded-[10px] bg-gray-200 active:cursor-grabbing"
+        aria-label="시트 드래그 핸들"
+      />
+      <div className="scrollbar-hide max-h-[calc(100%-4rem)] overflow-y-auto px-4">
         {children}
       </div>
     </div>

--- a/src/shared/components/button/button.tsx
+++ b/src/shared/components/button/button.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cn } from '@/shared/libs/cn';
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'black' | 'white' | 'gray';
+  variant?: 'black' | 'white' | 'gray' | 'outline';
   loading?: boolean;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
@@ -27,6 +27,8 @@ export default function Button({
     black: 'bg-gray-900 text-white',
     white: 'bg-gray-100 text-gray-700',
     gray: 'bg-gray-900 text-white opacity-50',
+    outline:
+      'bg-white text-black outline outline-1 outline-offset-[-1px] outline-gray-200',
   } as const;
 
   return (

--- a/src/shared/components/button/button.tsx
+++ b/src/shared/components/button/button.tsx
@@ -36,7 +36,7 @@ export default function Button({
       {...props}
     >
       {leftIcon ? <span className="shrink-0">{leftIcon}</span> : null}
-      <span className="text-body3">{children}</span>
+      <span className="body3">{children}</span>
       {rightIcon ? <span className="shrink-0">{rightIcon}</span> : null}
     </button>
   );

--- a/src/shared/components/chips/filter-chip.tsx
+++ b/src/shared/components/chips/filter-chip.tsx
@@ -14,7 +14,7 @@ export default function FilterChip({
   ...props
 }: FilterChipProps) {
   const base =
-    'flex-items-center gap-[0.8rem] rounded-full px-[1rem] py-[0.35rem] text-body4';
+    'flex-items-center gap-[0.8rem] rounded-full px-[1rem] py-[0.35rem] body4';
   const off = 'bg-white text-black ring-1 ring-gray-300';
   const on = 'bg-secondary text-primary ring-1 ring-primary';
 
@@ -25,7 +25,7 @@ export default function FilterChip({
       className={cn(base, selected ? on : off, className)}
       {...props}
     >
-      <span className="text-body4">{label}</span>
+      <span className="body4">{label}</span>
       <Icon
         name="filter"
         size={2.4}

--- a/src/shared/components/chips/filter-chip.tsx
+++ b/src/shared/components/chips/filter-chip.tsx
@@ -14,7 +14,7 @@ export default function FilterChip({
   ...props
 }: FilterChipProps) {
   const base =
-    'flex-items-center gap-[0.8rem] rounded-full px-[1rem] py-[0.35rem] body4';
+    'flex-items-center cursor-pointer gap-[0.8rem] rounded-full px-[1rem] py-[0.35rem] body4';
   const off = 'bg-white text-black ring-1 ring-gray-300';
   const on = 'bg-secondary text-primary ring-1 ring-primary';
 

--- a/src/shared/components/chips/tag.tsx
+++ b/src/shared/components/chips/tag.tsx
@@ -16,7 +16,7 @@ export default function Tag({
   ...props
 }: TagProps) {
   const base =
-    'flex-items-center rounded-full px-[1.2rem] py-[0.5rem] cursor-pointer text-body3';
+    'flex-items-center rounded-full px-[1.2rem] py-[0.5rem] cursor-pointer body3';
   const off = 'bg-white text-black ring-1 ring-gray-300';
   const on = 'bg-secondary text-primary ring-1 ring-primary';
 
@@ -28,7 +28,7 @@ export default function Tag({
       {...props}
     >
       {leftIcon && <span className="shrink-0">{leftIcon}</span>}
-      <span className="text-body3">{children}</span>
+      <span className="body3">{children}</span>
       {rightIcon && <span className="shrink-0">{rightIcon}</span>}
     </button>
   );

--- a/src/shared/components/step-dot.tsx
+++ b/src/shared/components/step-dot.tsx
@@ -33,12 +33,12 @@ export default function StepDot({
         aria-current={isCurrent ? 'step' : undefined}
         aria-label={`${number} ${isDone ? doneLabel : stepLabel}`}
       >
-        {isDone ? <CheckIcon /> : <span className="text-body3">{number}</span>}
+        {isDone ? <CheckIcon /> : <span className="body3">{number}</span>}
       </div>
 
       <span
         className={cn(
-          'text-caption2 mt-[0.8rem]',
+          'caption2 mt-[0.8rem]',
           isDone ? STEPPER_COLOR.label.dim : STEPPER_COLOR.label.default,
         )}
       >

--- a/src/shared/components/text-field/radio-tile-group.tsx
+++ b/src/shared/components/text-field/radio-tile-group.tsx
@@ -59,10 +59,7 @@ export default function RadioTileGroup<T extends string>({
               )}
             >
               <span
-                className={cn(
-                  'text-body3 text-black',
-                  'peer-checked:text-primary',
-                )}
+                className={cn('body3 text-black', 'peer-checked:text-primary')}
               >
                 {opt.label}
               </span>
@@ -70,7 +67,7 @@ export default function RadioTileGroup<T extends string>({
               {opt.right && (
                 <span
                   className={cn(
-                    'text-body4 text-black',
+                    'body4 text-black',
                     'peer-checked:text-primary',
                   )}
                 >

--- a/src/shared/components/text-field/radio-tile-group.tsx
+++ b/src/shared/components/text-field/radio-tile-group.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { cn } from '@/shared/libs/cn';
 
-// T = 리터럴 유니온('none' | 'delivery' | 'pickup' 등)
 type Option<T extends string> = {
   value: T;
   label: React.ReactNode;
@@ -15,6 +14,7 @@ type Props<T extends string> = {
   onChange: (v: T) => void;
   options: Option<T>[];
   className?: string;
+  rounded?: string;
 };
 
 export default function RadioTileGroup<T extends string>({
@@ -22,13 +22,14 @@ export default function RadioTileGroup<T extends string>({
   value,
   onChange,
   options,
-  className,
+  className = 'flex-col',
+  rounded = 'rounded-[0.4rem]',
 }: Props<T>) {
   const uid = React.useId();
   const groupName = name ?? `rtg-${uid}`;
 
   return (
-    <div className={cn('w-full flex-col gap-[1.2rem]', className)}>
+    <div className={cn('w-full gap-[1.2rem]', className)}>
       {options.map((opt) => {
         const id = `${groupName}-${opt.value}`;
         const checked = value === opt.value;
@@ -51,11 +52,12 @@ export default function RadioTileGroup<T extends string>({
 
             <div
               className={cn(
-                'flex items-center justify-between rounded-[0.4rem] border p-[1.6rem] transition-colors',
+                'flex items-center justify-between border p-[1.6rem] transition-colors',
                 'border-gray-200 bg-white',
                 'peer-focus-visible:ring-2 peer-focus-visible:ring-orange-200',
                 'peer-checked:bg-secondary peer-checked:border-primary peer-checked:[&>span:first-child]:text-primary',
                 opt.disabled && 'pointer-events-none opacity-60',
+                rounded,
               )}
             >
               <span

--- a/src/shared/components/text-field/search-text-field.tsx
+++ b/src/shared/components/text-field/search-text-field.tsx
@@ -77,7 +77,7 @@ export default function SearchTextField({
   );
 
   const inputClass =
-    'flex-1 bg-transparent outline-none placeholder:text-gray-400 text-body4 text-gray-900';
+    'flex-1 bg-transparent outline-none placeholder:text-gray-400 body4 text-gray-900';
 
   return (
     <form
@@ -107,7 +107,12 @@ export default function SearchTextField({
           ].join(' ')}
         >
           {showSearchIcon && (
-            <Icon name="search" size={2} ariaHidden className="shrink-0 text-gray-400" />
+            <Icon
+              name="search"
+              size={2}
+              ariaHidden
+              className="shrink-0 text-gray-400"
+            />
           )}
 
           <input
@@ -128,8 +133,17 @@ export default function SearchTextField({
 
           {/* 클리어(X) — 값 있을 때만 */}
           {val?.length > 0 && (
-            <button type="button" onClick={handleClear} aria-label="입력 지우기">
-              <Icon className="text-gray-300" name="clear" size={2.4} ariaHidden />
+            <button
+              type="button"
+              onClick={handleClear}
+              aria-label="입력 지우기"
+            >
+              <Icon
+                className="text-gray-300"
+                name="clear"
+                size={2.4}
+                ariaHidden
+              />
             </button>
           )}
         </div>

--- a/src/shared/layouts/bottom-navbar.tsx
+++ b/src/shared/layouts/bottom-navbar.tsx
@@ -96,10 +96,7 @@ export default function BottomNavigation({
               className={cn('text-gray-400', active && 'text-primary')}
             />
             <p
-              className={cn(
-                'text-caption4 text-gray-400',
-                active && 'text-primary',
-              )}
+              className={cn('caption4 text-gray-400', active && 'text-primary')}
             >
               {label}
             </p>

--- a/src/shared/layouts/top-bar.tsx
+++ b/src/shared/layouts/top-bar.tsx
@@ -53,7 +53,7 @@ export default function TopBar({
           ))}
       </div>
 
-      <h1 className="text-body3 truncate text-center text-gray-900">{title}</h1>
+      <h1 className="body3 truncate text-center text-gray-900">{title}</h1>
 
       <div className="justify-self-end">
         {rightSlot ??

--- a/src/shared/mocks/products.ts
+++ b/src/shared/mocks/products.ts
@@ -149,3 +149,43 @@ export const mockPickupProducts: Product[] = [
       '레스토랑 루미에르의 스페셜 디너 밀키트로 특별한 미식을 만나보세요. 신선한 재료로 정성껏 준비한 트러플 크림 파스타, 깊은 풍미의 허브그릴 스테이크, 그리고 계절 재료를 활용한 시트러스 해산물 샐러드를 최대 50% 할인된 가격에 제공합니다. 모든 요리는 엄격한 품질 관리 아래 조리되었으며, 오늘 저녁 9시부터 마감까지 한정 수량으로 선보입니다. 트러플 크림 파스타 (부드러운 식감과 진한 감칠맛), 허브그릴 스테이크 (신선한 재료의 조화로운 맛), 시트러스 해산물 샐러드 (계절 한정 특선) 중 재고 상황에 따라 포함됩니다. 조기 마감될 수 있으니 서둘러 방문해 주세요.',
   },
 ];
+
+const soongsilBase = { lat: 37.4963, lng: 126.9575 };
+export const testRestaurants = [
+  {
+    id: 1,
+    name: '정문돈까스',
+    lat: soongsilBase.lat + 0.0018,
+    lng: soongsilBase.lng - 0.0012,
+  },
+  {
+    id: 2,
+    name: '상도라멘',
+    lat: soongsilBase.lat + 0.001,
+    lng: soongsilBase.lng + 0.001,
+  },
+  {
+    id: 3,
+    name: '숭실카레집',
+    lat: soongsilBase.lat - 0.0012,
+    lng: soongsilBase.lng + 0.0008,
+  },
+  {
+    id: 4,
+    name: '상도불백',
+    lat: soongsilBase.lat - 0.0018,
+    lng: soongsilBase.lng - 0.001,
+  },
+  {
+    id: 5,
+    name: '홍콩반점 숭실',
+    lat: soongsilBase.lat + 0.0006,
+    lng: soongsilBase.lng - 0.0015,
+  },
+  {
+    id: 6,
+    name: '밥버거 숭실',
+    lat: soongsilBase.lat - 0.0005,
+    lng: soongsilBase.lng + 0.0016,
+  },
+];

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -11,7 +11,7 @@ const ProductDetailPage = lazy(
 );
 const MapViewPage = lazy(() => import('@/pages/main/map-view/map-view'));
 const SearchPage = lazy(() => import('@/pages/search/search-page'));
-const MenuPage = lazy(() => import('@/pages/menu/menu'));
+const MenuPage = lazy(() => import('@/pages/menu/menu-page'));
 const MyPage = lazy(() => import('@/pages/my-page/my-page'));
 const OrderPage = lazy(() => import('@/pages/order/order-page'));
 const MapPage = lazy(() => import('@/pages/map/map-page'));

--- a/src/shared/styles/custom-utilities.css
+++ b/src/shared/styles/custom-utilities.css
@@ -69,4 +69,8 @@
   .bottom-sheet {
     @apply fixed bottom-4 left-1/2 z-[1] max-w-[43rem];
   }
+
+  .bottom-modal {
+    @apply fixed bottom-0 left-1/2 z-[1] w-full max-w-[43rem] -translate-x-1/2;
+  }
 }

--- a/src/shared/styles/custom-utilities.css
+++ b/src/shared/styles/custom-utilities.css
@@ -56,11 +56,17 @@
   .header-layout {
     @apply sticky top-0 z-[var(--z-header)] h-[5.6rem] py-[1.55rem] pl-[2rem];
   }
+
   .scrollbar-hide {
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+
+  .bottom-sheet {
+    @apply fixed bottom-4 left-1/2 z-[1] max-w-[43rem];
   }
 }

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -28,6 +28,7 @@
   --z-header: 5;
   --z-overlay: 6;
   --z-bottom-nav: 7;
+  --z-bottom-modal: 8;
 
   /* Radius / Shadow */
   --radius-md: 12px;

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -54,7 +54,7 @@
    ========================================= */
 
   /* ===== Headings ===== */
-  .text-head1 {
+  .head1 {
     /* 22px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -62,7 +62,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-head2 {
+  .head2 {
     /* 20px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -70,7 +70,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-head3 {
+  .head3 {
     /* 18px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -80,7 +80,7 @@
   }
 
   /* ===== Body ===== */
-  .text-body1 {
+  .body1 {
     /* 16px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -88,7 +88,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-body2 {
+  .body2 {
     /* 16px, Medium */
     font-family: var(--font-sans);
     font-weight: 500;
@@ -96,7 +96,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-body3 {
+  .body3 {
     /* 14px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -104,7 +104,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-body4 {
+  .body4 {
     /* 14px, Medium */
     font-family: var(--font-sans);
     font-weight: 500;
@@ -114,7 +114,7 @@
   }
 
   /* ===== Captions ===== */
-  .text-caption1 {
+  .caption1 {
     /* 12px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -122,7 +122,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-caption2 {
+  .caption2 {
     /* 12px, Medium */
     font-family: var(--font-sans);
     font-weight: 500;
@@ -130,7 +130,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-caption3 {
+  .caption3 {
     /* 10px, Semibold */
     font-family: var(--font-sans);
     font-weight: 600;
@@ -138,7 +138,7 @@
     line-height: var(--lh);
     letter-spacing: var(--ls);
   }
-  .text-caption4 {
+  .caption4 {
     /* 10px, Medium */
     font-family: var(--font-sans);
     font-weight: 500;


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #23


## 🔎 What is this PR?

메뉴 페이지 UI를 구현했습니다. 지도/리스트 전환, 정렬·필터 모달, 바텀시트 동작 등 핵심 UX를 디자인 시스템 규칙에 맞춰 구현했습니다.

## 💡 해결한 이슈 목록

* [x] 지도/리스트 2가지 보기 모드 구성 및 전환
* [x] 검색 헤더 연동(엔터 시 `/search?q=` 네비게이션)
* [x] 바텀시트 드래그(최대 높이→오버드래그 시 리스트 전환)
* [x] 정렬 모달(인기순/가격↑/가격↓/거리순) + 적용 버튼 활성화 로직
* [x] 전체 화면 필터 모달(음식 타입/카테고리/가격대/수령 방법) + 초기화/적용
* [x] 필터 적용 시 `FilterChip` 상태/색상 동기화

## ✅ 변경사항

* **페이지/섹션**

  * `MenuPage` 신규: 모드/검색/프리뷰/정렬/필터 상태 관리
  * `MapSection`, `ListSection`, `PreviewCard`, `MenuHeader`, `SortFilterRow` 분리
* **모달/칩**

  * `SortModal`(임시선택→적용), `FilterModal`(풀스크린+TopBar) 추가
  * `FilterChip` 라벨 색 상속(`text-inherit`) 및 selected 스타일 안정화
* **공통/유틸**

  * `radio-tile-group` 그리드 레이아웃화 + `columns` prop 지원(2열 배치)
  * `button` 컴포넌트 `variant: outline/white/black` 정리(불필요 opacity 제거, ring 사용)
  * 상수/타입: `constants/sort.ts`, `constants/filter.ts`, `constants/menu.ts(SOONGSIL_BASE, SHEET)`
  * 유틸: `hasActiveFilters`(필터 적용 여부 계산)

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

