### PR TITLE
[Style] 메뉴 필터(sort modal) 색상 수정 #40

### DIFF
--- a/src/pages/menu/components/sort-modal.tsx
+++ b/src/pages/menu/components/sort-modal.tsx
@@ -13,7 +13,11 @@ export default function SortModal({ open, value, onChange, onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-[var(--z-bottom-modal)]">
-      <button aria-label="닫기" className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <button
+        aria-label="닫기"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+      />
       <div className="bottom-modal flex-col gap-[0.8rem] rounded-t-[2.4rem] bg-white pt-[1.6rem]">
         <div className="mx-auto h-[0.3rem] w-[5rem] rounded-[10px] bg-gray-200" />
         <div className="flex-col gap-[1.2rem]">
@@ -26,15 +30,20 @@ export default function SortModal({ open, value, onChange, onClose }: Props) {
                 <li key={opt.key}>
                   <button
                     className={cn(
-                      'block w-full cursor-pointer px-[1.6rem] py-[1.8rem] text-left',
-                      selected && 'bg-gray-100',
+                      'block w-full cursor-pointer px-[1.6rem] py-[1.8rem] text-left hover:bg-gray-100',
+                      selected && 'bg-secondary',
                     )}
                     onClick={() => {
                       onChange(opt.key);
                       onClose();
                     }}
                   >
-                    <span className={cn('body3 text-black', selected && 'font-medium')}>
+                    <span
+                      className={cn(
+                        'body3 text-black',
+                        selected && 'font-medium',
+                      )}
+                    >
                       {opt.label}
                     </span>
                   </button>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #40

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

메뉴 필터(정렬 모달) 항목의 선택 상태 색상과 호버 색상을 명확하게 보이도록 개선했습니다.
테마 토큰(bg-secondary)을 사용해 일관된 컬러 시스템을 유지하고, 호버 색상(hover:bg-gray-100)을 추가했습니다.


## 💡 해결한 이슈 목록

- [ ] 메뉴 필터(sort modal) select 색상 수정
- [ ] 메뉴 필터(sort modal) hover 색상 추가


## ✅ 변경사항

- `hover:bg-gray-100`
- `selected && 'bg-secondary`

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

