### PR TITLE
[Feat] 스켈레톤 로딩 도입 & 배너 플리커(깜빡임) 방지 #31

### DIFF
--- a/src/pages/main/components/product/product-card.tsx
+++ b/src/pages/main/components/product/product-card.tsx
@@ -12,6 +12,54 @@ export type ProductCardProps = {
   className?: string;
 };
 
+function Block({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn('animate-pulse rounded-[4px] bg-gray-100', className)}
+    />
+  );
+}
+
+export function ProductCardSkeleton({
+  variant = 'compact',
+  className,
+}: {
+  variant?: 'compact' | 'wide';
+  className?: string;
+}) {
+  if (variant === 'wide') {
+    return (
+      <article
+        className={cn(
+          'relative w-full flex-col gap-[1rem] overflow-hidden',
+          className,
+        )}
+      >
+        <Block className="aspect-[21/10] w-full" />
+        <div className="flex-col gap-[0.6rem]">
+          <Block className="h-[1.2rem] w-[30%]" />
+          <Block className="h-[1.6rem] w-[60%]" />
+          <Block className="h-[1.6rem] w-[40%]" />
+          <Block className="h-[1.2rem] w-[50%]" />
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className={cn('relative w-full overflow-hidden', className)}>
+      <Block className="h-[14rem] w-full" />
+      <div className="mt-[1rem] flex-col gap-[0.6rem]">
+        <Block className="h-[1.0rem] w-[40%]" />
+        <Block className="h-[1.2rem] w-[70%]" />
+        <Block className="h-[1.6rem] w-[50%]" />
+        <Block className="h-[1.0rem] w-[60%]" />
+      </div>
+    </article>
+  );
+}
+
 function ProductCard({
   product,
   variant = 'compact',
@@ -63,7 +111,6 @@ function ProductCard({
     );
   }
 
-  // compact
   return (
     <article
       className={cn(

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -2,7 +2,9 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '@/shared/components/icon';
 import Header, { type Mode } from '@/pages/main/components/main-header';
-import ProductCard from '@/pages/main/components/product/product-card';
+import ProductCard, {
+  ProductCardSkeleton,
+} from '@/pages/main/components/product/product-card';
 import Section from '@/pages/main/components/section-list';
 import Banner from '@/pages/main/components/banner-contents';
 import { mockDeliveryProducts, mockPickupProducts } from '@/shared/mocks';
@@ -10,7 +12,6 @@ import { ProfileModal } from './components/profile-modal';
 import { SECTION_META, type SectionKey } from '@/shared/constants/sections';
 import {
   MAIN_SECTIONS_ORDER,
-  getSectionTitle,
   DEFAULT_LOCATION_LABEL,
 } from '@/pages/main/constants/section';
 
@@ -18,17 +19,20 @@ export default function MainPage() {
   const navigate = useNavigate();
   const [mode, setMode] = useState<Mode>('delivery');
 
+  const [isLoading] = useState<boolean>(false);
+
   const data = useMemo(
     () => (mode === 'delivery' ? mockDeliveryProducts : mockPickupProducts),
     [mode],
   );
 
-  const ordered: SectionKey[] = ['nearby', 'new', 'lastcall', 'breakfast', 'dessert', 'now'];
-
   const getTitle = (key: SectionKey) => {
     const t = SECTION_META[key].title;
     return typeof t === 'string' ? t : t[mode];
   };
+
+  const SKELETON_COUNT = 8;
+  const skeletons = Array.from({ length: SKELETON_COUNT });
 
   return (
     <div className="h-full w-full bg-white pb-[2rem]">
@@ -75,13 +79,24 @@ export default function MainPage() {
             <Section
               key={key}
               sectionKey={key}
-              title={getSectionTitle(key, mode)}
+              title={getTitle(key)}
               mode={mode}
               itemWidthClass="w-[16.5rem]"
             >
-              {data.map((p) => (
-                <ProductCard key={`${key}-${p.id}`} product={p} variant="compact" />
-              ))}
+              {isLoading
+                ? skeletons.map((_, i) => (
+                    <ProductCardSkeleton
+                      key={`s-${key}-${i}`}
+                      variant="compact"
+                    />
+                  ))
+                : data.map((p) => (
+                    <ProductCard
+                      key={`${key}-${p.id}`}
+                      product={p}
+                      variant="compact"
+                    />
+                  ))}
             </Section>
           ))}
         </div>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #31

## 🔎 What is this PR?

* 상품 카드에 **스켈레톤 로딩**을 적용해 초기 로딩 UX 개선
* 배너 영역의 **초기/전환 시 깜빡임(플리커링)** 방지로 렌더 안정화

## 💡 해결한 이슈 목록

* [x] 리스트 로딩 시 스켈레톤 노출
* [x] 섹션 레이아웃 점프(CLS) 최소화
* [x] 배너 초기/슬라이드 전환 시 깜빡임 제거

## ✅ 변경사항

* `ProductCard`에 `ProductCardSkeleton` 추가 (compact/wide 대응)
* `MainPage` 상위에서 `isLoading` 분기 적용, 카드/스켈레톤 동일 폭 처리
* 배너: 이미지 **선로딩/디코드 + 컨테이너 비율 고정**으로 플리커 방지(예: `aspect-*`, `decode()/onload`, 페이드 전환)



