### PR TITLE
[Feat] 상품 상세 뱃지 추가 #60

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,21 @@ import { RouterProvider } from 'react-router-dom';
 import LoopLoading from '@/shared/components/loop-loading';
 import queryClient from '@/shared/libs/query-client';
 import { router } from '@/shared/routes/router';
+import useSplash from '@/shared/hooks/use-splash';
+import Splash from '@/shared/components/splash/splash';
 
 export default function App() {
+  const { visible, hide } = useSplash({ minShowMs: 900 });
+
   return (
     <QueryClientProvider client={queryClient}>
-      <Suspense fallback={<LoopLoading />}>
-        <RouterProvider router={router} />
-      </Suspense>
+      <div className="relative">
+        <Suspense fallback={<LoopLoading />}>
+          <RouterProvider router={router} />
+        </Suspense>
+
+        {visible && <Splash onFinish={hide} />}
+      </div>
     </QueryClientProvider>
   );
 }

--- a/src/pages/main/product-detail/components/badge.tsx
+++ b/src/pages/main/product-detail/components/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cn } from '@/shared/libs/cn';
+
+type BadgeProps = {
+  as?: 'span' | 'div' | 'button';
+  className?: string;
+  children: React.ReactNode;
+  tone?: 'primary' | 'neutral';
+};
+
+const Badge = React.forwardRef<HTMLElement, BadgeProps>(
+  ({ as = 'span', className, children, tone = 'primary', ...rest }, ref) => {
+    const Comp = as as any;
+    return (
+      <Comp
+        ref={ref}
+        {...rest}
+        className={cn(
+          'caption2 flex items-center rounded-[4px] px-[0.6rem] py-[0.3rem] whitespace-nowrap select-none',
+          tone === 'primary' && 'text-primary bg-gray-100',
+          tone === 'neutral' && 'bg-gray-100 text-gray-700',
+          className,
+        )}
+      >
+        <span className="caption3">{children}</span>
+      </Comp>
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+export default Badge;

--- a/src/pages/main/product-detail/components/info-row.tsx
+++ b/src/pages/main/product-detail/components/info-row.tsx
@@ -1,18 +1,25 @@
 import Icon from '@/shared/components/icon';
 
-function InfoRow({
-  icon,
-  text,
-  trailing,
-}: {
-  icon: 'location' | 'clock' | 'cart' | 'phone';
+type InfoRowProps = {
+  icon?: 'location' | 'clock' | 'cart' | 'phone';
+  iconSizeRem?: number;
   text: React.ReactNode;
   trailing?: React.ReactNode;
-}) {
+};
+
+function InfoRow({ icon, iconSizeRem = 2.4, text, trailing }: InfoRowProps) {
+  const boxSize = `${iconSizeRem}rem`;
+
   return (
     <div className="flex items-center justify-start gap-[1.2rem]">
       <div className="body4 flex items-center gap-[0.4rem] text-black">
-        <Icon name={icon} size={2.4} />
+        <span
+          className="inline-flex flex-shrink-0 items-center justify-center"
+          style={{ width: boxSize, height: boxSize }}
+          aria-hidden
+        >
+          {icon ? <Icon name={icon} size={iconSizeRem} /> : null}
+        </span>
         <span>{text}</span>
       </div>
       {trailing}

--- a/src/pages/main/product-detail/product-detail-page.tsx
+++ b/src/pages/main/product-detail/product-detail-page.tsx
@@ -9,6 +9,14 @@ import Icon from '@/shared/components/icon';
 import { formatKRW } from '@/shared/utils/format-krw';
 import InfoTooltipButton from '@/pages/main/product-detail/components/info-tooltip';
 import { getRemainingBadge } from '@/pages/main/checkout/utils/stock';
+import Badge from '@/pages/main/product-detail/components/badge';
+
+const MethodText = ({ label, time }: { label: string; time: string }) => (
+  <div className="flex items-center gap-[0.4rem]">
+    <Badge>{label}</Badge>
+    <span className="body3 whitespace-nowrap text-black">{time}</span>
+  </div>
+);
 
 export default function ProductDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -31,7 +39,6 @@ export default function ProductDetailPage() {
     originalPrice,
     pickupPrice,
     address,
-    hours,
     teamDeliveryAfter,
     phone,
     stockLeft,
@@ -134,34 +141,35 @@ export default function ProductDetailPage() {
             </div>
           </section>
           <section className="flex-col gap-[0.8rem]">
-            {address && (
+            <InfoRow
+              icon="location"
+              text={address}
+              trailing={
+                <button
+                  onClick={() => navigate('/map-view')}
+                  className="text-primary flex-row-center cursor-pointer gap-[0.4rem]"
+                >
+                  <Icon name="map" size={2.4} />
+                  <span className="caption2">지도에서 보기</span>
+                </button>
+              }
+            />
+            <div className="flex-col gap-[0.4rem]">
               <InfoRow
-                icon="location"
-                text={address}
-                trailing={
-                  <button
-                    onClick={() => navigate('/map-view')}
-                    className="text-primary flex-row-center cursor-pointer gap-[0.4rem]"
-                  >
-                    <Icon name="map" size={2.4} />
-                    <span className="caption2">지도에서 보기</span>
-                  </button>
-                }
+                icon="cart"
+                text={<MethodText label="픽업" time="17:15 ~ 18:00" />}
               />
-            )}
-            {hours && <InfoRow icon="clock" text={hours} />}
-            {teamDeliveryAfter && (
-              <InfoRow icon="cart" text={teamDeliveryAfter} />
-            )}
+              <InfoRow
+                text={<MethodText label="팀배달" time="17:15 ~ 18:00" />}
+              />
+            </div>
             {phone && <InfoRow icon="phone" text={phone} />}
           </section>
-          {teamDeliveryAfter && (
-            <section>
-              <div className="body4 rounded-[4px] bg-gray-50 p-[1.6rem] text-center text-black">
-                {teamDeliveryAfter} 팀배달이 가능한 상품이에요
-              </div>
-            </section>
-          )}
+          <section>
+            <div className="body4 rounded-[4px] bg-gray-50 p-[1.6rem] text-center text-black">
+              {teamDeliveryAfter} 팀배달이 가능한 상품이에요
+            </div>
+          </section>
           <section className="flex-col gap-[1.2rem]">
             <h2 className="body1 text-black">상품 설명</h2>
             <p className="body4 text-black">{description}</p>

--- a/src/shared/components/splash/splash.tsx
+++ b/src/shared/components/splash/splash.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@/shared/libs/cn';
+import Icon from '@/shared/components/icon';
+
+type Props = {
+  onFinish?: () => void;
+  fadeMs?: number;
+  dismissible?: boolean;
+};
+
+export default function Splash({
+  onFinish,
+  fadeMs = 400,
+  dismissible = true,
+}: Props) {
+  const [leaving, setLeaving] = useState(false);
+
+  const close = () => {
+    if (leaving) return;
+    setLeaving(true);
+    const t = setTimeout(() => onFinish?.(), fadeMs);
+    return () => clearTimeout(t);
+  };
+
+  useEffect(() => {
+    return () => {};
+  }, []);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      onClick={dismissible ? close : undefined}
+      className={cn(
+        'flex-col-center fixed inset-0 z-[999] gap-[1.2rem]',
+        'bg-primary text-black select-none',
+        leaving
+          ? 'opacity-0 transition-opacity duration-[400ms]'
+          : 'opacity-100',
+      )}
+      style={{ transitionDuration: `${fadeMs}ms` }}
+    >
+      <Icon name="logo-title" width={12} height={2.6} className="text-white" />
+    </div>
+  );
+}

--- a/src/shared/hooks/use-splash.ts
+++ b/src/shared/hooks/use-splash.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+type Options = {
+  minShowMs?: number;
+  autoHide?: boolean;
+};
+
+export default function useSplash({
+  minShowMs = 900,
+  autoHide = true,
+}: Options = {}) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (!autoHide) return;
+    const t = setTimeout(() => setVisible(false), minShowMs);
+    return () => clearTimeout(t);
+  }, [minShowMs, autoHide]);
+
+  return { visible, hide: () => setVisible(false) };
+}


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #60

## 🔎 What is this PR?

* 상품 상세 화면에 **픽업/팀배달 뱃지**와 **이용 가능 시간**을 함께 표시합니다.
* 디자인 스펙(H 24px, r 4px, 좌우 패딩 6px, 라이트 그레이 배경, 프라이머리 텍스트)을 반영했습니다.

## 💡 해결한 이슈 목록

* [x] 픽업/팀배달 뱃지 구현

## ✅ 변경사항

* `shared/components/badge` 컴포넌트 도입 (재사용 가능)
* `ProductDetailPage`에 배지+시간 묶음(View) 적용 (`MethodRow`)
* `InfoRow`의 `text` prop에 ReactNode 전달하도록 사용 패턴 확장
* 아이콘 권장: 픽업 = `bag`, 팀배달 = `cart` (구분 가독성 향상)


