### PR TITLE
[Feat] 주문 목록 조회/취소 API 연동 #70

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import queryClient from '@/shared/libs/query-client';
 import { router } from '@/shared/routes/router';
 import useSplash from '@/shared/hooks/use-splash';
 import Splash from '@/shared/components/splash/splash';
+import { ToastProvider } from '@/shared/contexts/ToastContext';
 
 export default function App() {
   const { visible, hide } = useSplash({ minShowMs: 1000 });
@@ -14,7 +15,9 @@ export default function App() {
     <QueryClientProvider client={queryClient}>
       <div className="relative">
         <Suspense fallback={<LoopLoading />}>
-          <RouterProvider router={router} />
+          <ToastProvider>
+            <RouterProvider router={router} />
+          </ToastProvider>
         </Suspense>
 
         {visible && <Splash onFinish={hide} />}

--- a/src/assets/icons/toast-close.svg
+++ b/src/assets/icons/toast-close.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 10 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 1L1.5 8" stroke="currentColor" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.5 1L8.5 8" stroke="currentColor" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/toast-info.svg
+++ b/src/assets/icons/toast-info.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 2 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 9.5V5.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 1.5H1.01" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/toast-success.svg
+++ b/src/assets/icons/toast-success.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 3.25725L4 6.16634L9 0.833008" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/order/components/order-card.tsx
+++ b/src/pages/order/components/order-card.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const SavedBadge = ({ g }: { g: number }) => (
-  <span className="caption1 inline-flex items-center rounded-[999px] bg-[#ffe7e4] px-[1.2rem] py-[0.6rem] text-[#ff6a6a]">
+  <span className="caption1 bg-secondary text-primary flex w-[10.6rem] items-center rounded-[20px] px-[1.2rem] py-[0.5rem]">
     {g.toLocaleString()}g 절약했어요
   </span>
 );
@@ -33,28 +33,32 @@ export default function OrderCard({ item, onCancel, onReorder }: Props) {
   return (
     <article className="rounded-[12px] border border-gray-200 bg-white p-[1.6rem] shadow-[0_0.2rem_0.6rem_rgba(0,0,0,0.04)]">
       {/* 상단: 썸네일 + 텍스트 */}
-      <div className="flex gap-[1.2rem]">
+      <div className="flex gap-[1rem]">
         <img
           src={item.image}
           alt=""
-          className="h-[7.2rem] w-[7.2rem] rounded-[8px] object-cover"
+          className="h-[8rem] w-[8rem] rounded-[8px] object-cover"
           draggable={false}
         />
         <div className="min-w-0 flex-1">
-          <p className="body3 truncate text-gray-500">{item.store}</p>
-          <p className="body2 truncate text-black">{item.name}</p>
+          <p className="caption1 truncate text-black">{item.store}</p>
+          <p className="body4 truncate text-black">{item.name}</p>
 
-          <div className="mt-[0.6rem] flex flex-wrap items-center gap-x-[0.8rem] gap-y-[0.4rem]">
-            <span className="body4 text-[#ff6a6a]">{item.discountRate}%</span>
-            <span className="head4 text-black">
-              {formatKRW(item.salePrice)}
-            </span>
-            <s className="caption1 text-gray-400">
-              {formatKRW(item.originalPrice)}
-            </s>
-            <span className="caption1 text-gray-400">· {item.qty}개</span>
+          <div className="flex flex-wrap items-center">
+            <div className="flex flex-wrap items-center gap-[0.4rem]">
+              <span className="caption1 text-primary">
+                {item.discountRate}%
+              </span>
+              <span className="body3 text-black">
+                {formatKRW(item.salePrice)}
+              </span>
+              <s className="caption2 text-gray-300">
+                {formatKRW(item.originalPrice)}
+              </s>
+            </div>
+            <span className="caption1 text-gray-700">・</span>
+            <span className="caption2 text-gray-700">{item.qty}개</span>
           </div>
-
           {item.pickupPriceText && (
             <div className="mt-[0.4rem]">
               <span className="caption1 rounded-[6px] bg-[#eaf2ff] px-[0.6rem] py-[0.2rem] text-[#2f6dff]">
@@ -69,8 +73,8 @@ export default function OrderCard({ item, onCancel, onReorder }: Props) {
       <div className="my-[1.2rem] h-[0.1rem] w-full bg-gray-200/80" />
 
       {/* 총 결제금액 + 절약 배지 */}
-      <div className="flex items-end justify-between gap-[1.2rem]">
-        <div className="flex items-center gap-[0.8rem]">
+      <div className="w-full flex-col gap-[0.6rem]">
+        <div className="flex items-center justify-between gap-[0.8rem]">
           <span className="body2 whitespace-nowrap text-black">
             총 결제금액
           </span>
@@ -79,11 +83,13 @@ export default function OrderCard({ item, onCancel, onReorder }: Props) {
             <s className="caption1 text-gray-400">{formatKRW(originalTotal)}</s>
           </div>
         </div>
-        <SavedBadge g={item.savedGram} />
+        <div className="w-full flex-col items-end justify-start">
+          <SavedBadge g={item.savedGram} />
+        </div>
       </div>
 
       {/* 하단 버튼 */}
-      <div className="mt-[1.2rem]">
+      <div>
         {showReorder ? (
           <Button
             variant="black"

--- a/src/pages/order/components/order-card.tsx
+++ b/src/pages/order/components/order-card.tsx
@@ -1,0 +1,109 @@
+import Button from '@/shared/components/button/button';
+import { formatKRW } from '@/shared/utils/format-krw';
+import type { OrderItem } from '../types/order';
+import { ORDER_STATUS } from '../constants/order';
+
+interface Props {
+  item: OrderItem;
+  onCancel?: (id: string) => void;
+  onReorder?: (id: string) => void;
+}
+
+const SavedBadge = ({ g }: { g: number }) => (
+  <span className="caption1 inline-flex items-center rounded-[999px] bg-[#ffe7e4] px-[1.2rem] py-[0.6rem] text-[#ff6a6a]">
+    {g.toLocaleString()}g 절약했어요
+  </span>
+);
+
+export default function OrderCard({ item, onCancel, onReorder }: Props) {
+  const total = item.salePrice * item.qty;
+  const originalTotal = item.originalPrice * item.qty;
+
+  const canCancel =
+    item.status === ORDER_STATUS.CANCELLABLE ||
+    item.status === ORDER_STATUS.IN_PROGRESS;
+  const showReorder =
+    item.status === ORDER_STATUS.DELIVERED ||
+    item.status === ORDER_STATUS.SOLD_OUT;
+  const disabledMsg =
+    item.status === ORDER_STATUS.SOLD_OUT
+      ? '품절된 상품이에요'
+      : '주문 취소하기';
+
+  return (
+    <article className="rounded-[12px] border border-gray-200 bg-white p-[1.6rem] shadow-[0_0.2rem_0.6rem_rgba(0,0,0,0.04)]">
+      {/* 상단: 썸네일 + 텍스트 */}
+      <div className="flex gap-[1.2rem]">
+        <img
+          src={item.image}
+          alt=""
+          className="h-[7.2rem] w-[7.2rem] rounded-[8px] object-cover"
+          draggable={false}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="body3 truncate text-gray-500">{item.store}</p>
+          <p className="body2 truncate text-black">{item.name}</p>
+
+          <div className="mt-[0.6rem] flex flex-wrap items-center gap-x-[0.8rem] gap-y-[0.4rem]">
+            <span className="body4 text-[#ff6a6a]">{item.discountRate}%</span>
+            <span className="head4 text-black">
+              {formatKRW(item.salePrice)}
+            </span>
+            <s className="caption1 text-gray-400">
+              {formatKRW(item.originalPrice)}
+            </s>
+            <span className="caption1 text-gray-400">· {item.qty}개</span>
+          </div>
+
+          {item.pickupPriceText && (
+            <div className="mt-[0.4rem]">
+              <span className="caption1 rounded-[6px] bg-[#eaf2ff] px-[0.6rem] py-[0.2rem] text-[#2f6dff]">
+                {item.pickupPriceText}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 구분선 */}
+      <div className="my-[1.2rem] h-[0.1rem] w-full bg-gray-200/80" />
+
+      {/* 총 결제금액 + 절약 배지 */}
+      <div className="flex items-end justify-between gap-[1.2rem]">
+        <div className="flex items-end gap-[0.8rem]">
+          <span className="body2 text-black">총 결제금액</span>
+          <div className="flex items-baseline gap-[0.6rem]">
+            <span className="head3 text-black">{formatKRW(total)}</span>
+            <s className="caption1 text-gray-400">{formatKRW(originalTotal)}</s>
+          </div>
+        </div>
+        <SavedBadge g={item.savedGram} />
+      </div>
+
+      {/* 하단 버튼 */}
+      <div className="mt-[1.2rem]">
+        {showReorder ? (
+          <Button
+            variant="black"
+            className="w-full"
+            disabled={item.status === ORDER_STATUS.SOLD_OUT}
+            onClick={() => onReorder?.(item.id)}
+          >
+            {item.status === ORDER_STATUS.SOLD_OUT
+              ? '품절된 상품이에요'
+              : '같은 상품 주문하기'}
+          </Button>
+        ) : (
+          <Button
+            variant="black"
+            className="w-full"
+            disabled={!canCancel}
+            onClick={() => onCancel?.(item.id)}
+          >
+            {canCancel ? '주문 취소하기' : disabledMsg}
+          </Button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/pages/order/components/order-card.tsx
+++ b/src/pages/order/components/order-card.tsx
@@ -70,8 +70,10 @@ export default function OrderCard({ item, onCancel, onReorder }: Props) {
 
       {/* 총 결제금액 + 절약 배지 */}
       <div className="flex items-end justify-between gap-[1.2rem]">
-        <div className="flex items-end gap-[0.8rem]">
-          <span className="body2 text-black">총 결제금액</span>
+        <div className="flex items-center gap-[0.8rem]">
+          <span className="body2 whitespace-nowrap text-black">
+            총 결제금액
+          </span>
           <div className="flex items-baseline gap-[0.6rem]">
             <span className="head3 text-black">{formatKRW(total)}</span>
             <s className="caption1 text-gray-400">{formatKRW(originalTotal)}</s>

--- a/src/pages/order/components/order-tabs.tsx
+++ b/src/pages/order/components/order-tabs.tsx
@@ -1,0 +1,55 @@
+import type { OrderTabKey } from '@/pages/order/constants/order';
+
+type Tab = { key: OrderTabKey; label: string };
+
+type Props = {
+  tabs: readonly Tab[];
+  active: OrderTabKey;
+  onChange: (key: OrderTabKey) => void;
+  topOffsetRem?: number;
+  className?: string;
+};
+
+export default function OrderTabs({
+  tabs,
+  active,
+  onChange,
+  topOffsetRem = 4.8,
+  className = '',
+}: Props) {
+  const topStyle = { top: `${topOffsetRem}rem` };
+
+  return (
+    <aside
+      className={`sticky z-[var(--z-header)] bg-white ${className}`}
+      style={topStyle}
+    >
+      <nav role="tablist" aria-label="주문 내역 탭">
+        <div className="flex h-[4.8rem] items-center">
+          {tabs.map((t) => {
+            const isActive = t.key === active;
+            return (
+              <button
+                key={t.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className="relative flex-1 pb-[1.2rem] text-center"
+                onClick={() => onChange(t.key)}
+              >
+                <span
+                  className={`body2 ${isActive ? 'text-black' : 'text-gray-400'}`}
+                >
+                  {t.label}
+                </span>
+                {isActive && (
+                  <span className="absolute right-0 bottom-0 left-0 h-[0.2rem] rounded-[999px] bg-black" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/src/pages/order/constants/order.ts
+++ b/src/pages/order/constants/order.ts
@@ -1,0 +1,14 @@
+export const ORDER_TABS = [
+  { key: 'delivery', label: '배달' },
+  { key: 'pickup', label: '픽업' },
+] as const;
+
+export type OrderTabKey = (typeof ORDER_TABS)[number]['key'];
+
+export const ORDER_STATUS = {
+  IN_PROGRESS: 'IN_PROGRESS', // 주문 진행 중
+  DELIVERED: 'DELIVERED', // 배달완료
+  CANCELLABLE: 'CANCELLABLE', // 취소 가능(진행 중)
+  SOLD_OUT: 'SOLD_OUT', // 품절
+} as const;
+export type OrderStatus = (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS];

--- a/src/pages/order/order-page.tsx
+++ b/src/pages/order/order-page.tsx
@@ -77,11 +77,11 @@ export default function OrderHistoryPage() {
         topOffsetRem={4.4}
       />
 
-      <main className="flex flex-col gap-[2rem] px-[2rem] py-[1.6rem]">
+      <main className="flex-col gap-[2rem] px-[2rem] py-[1.6rem]">
         {isFetching && <p className="caption1 text-gray-400">불러오는 중…</p>}
 
         {list.map((item) => (
-          <section key={item.id} className="flex flex-col gap-[0.8rem]">
+          <section key={item.id} className="flex-col gap-[1.6rem]">
             <p className="caption1 text-gray-400">
               {formatDateLine(item.orderedAt, item.status, item.method)}
             </p>

--- a/src/pages/order/order-page.tsx
+++ b/src/pages/order/order-page.tsx
@@ -1,3 +1,159 @@
-export default function OrderPage() {
-  return <div className="flex-col-between min-h-[100dvh] bg-white">주문내역 페이지</div>;
+import { useMemo, useState } from 'react';
+import TopBar from '@/shared/layouts/top-bar';
+import { ORDER_STATUS, ORDER_TABS, type OrderTabKey } from './constants/order';
+import type { OrderItem } from './types/order';
+import OrderCard from './components/order-card';
+import { useNavigate } from 'react-router-dom';
+
+// --- 샘플 데이터 (API 연동 전 UI 확인용) ---
+const base: Omit<OrderItem, 'id' | 'orderedAt' | 'method' | 'status'> = {
+  image: '/sample/order-thumb.jpg',
+  store: '스타벅스 송실대입구역점',
+  name: '시크릿 런치 밀박스',
+  discountRate: 20,
+  salePrice: 10800,
+  originalPrice: 13500,
+  qty: 2,
+  savedGram: 560,
+  pickupPriceText: '픽업 시 9,800원',
+};
+
+const mockOrders: OrderItem[] = [
+  {
+    id: 'd1',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'delivery',
+    status: ORDER_STATUS.CANCELLABLE,
+    ...base,
+  },
+  {
+    id: 'd2',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'delivery',
+    status: ORDER_STATUS.IN_PROGRESS,
+    ...base,
+  },
+  {
+    id: 'd3',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'delivery',
+    status: ORDER_STATUS.DELIVERED,
+    ...base,
+  },
+  {
+    id: 'd4',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'delivery',
+    status: ORDER_STATUS.SOLD_OUT,
+    ...base,
+  },
+
+  {
+    id: 'p1',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'pickup',
+    status: ORDER_STATUS.CANCELLABLE,
+    ...base,
+  },
+  {
+    id: 'p2',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'pickup',
+    status: ORDER_STATUS.IN_PROGRESS,
+    ...base,
+  },
+  {
+    id: 'p3',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'pickup',
+    status: ORDER_STATUS.DELIVERED,
+    ...base,
+  },
+  {
+    id: 'p4',
+    orderedAt: '2025-08-16T22:16:00+09:00',
+    method: 'pickup',
+    status: ORDER_STATUS.SOLD_OUT,
+    ...base,
+  },
+];
+
+const formatDateLine = (
+  iso: string,
+  status: string,
+  method: OrderItem['method'],
+) => {
+  const d = new Date(iso);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = d.getHours() % 12 || 12;
+  const ap = d.getHours() >= 12 ? '오후' : '오전';
+  const mi = String(d.getMinutes()).padStart(2, '0');
+
+  const statusText =
+    status === ORDER_STATUS.CANCELLABLE || status === ORDER_STATUS.IN_PROGRESS
+      ? '주문 진행 중'
+      : method === 'delivery'
+        ? '배달완료'
+        : undefined;
+
+  return `${yyyy}. ${mm}. ${dd} ${ap} ${hh}시 ${mi}분${statusText ? ' ・ ' + statusText : ''}`;
+};
+
+export default function OrderHistoryPage() {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<OrderTabKey>('delivery');
+
+  const list = useMemo(() => mockOrders.filter((o) => o.method === tab), [tab]);
+
+  const onCancel = (id: string) => {
+    console.log('cancel', id);
+  };
+  const onReorder = (id: string) => {
+    console.log('reorder', id);
+  };
+
+  return (
+    <div className="scrollbar-hide h-dvh flex-col overflow-y-auto bg-white">
+      <TopBar title="주문내역" showBack onBack={() => navigate(-1)} sticky />
+
+      <div className="px-[2rem]">
+        <div className="flex h-[4.8rem] items-center gap-[2.4rem]">
+          {ORDER_TABS.map((t) => {
+            const active = t.key === tab;
+            return (
+              <button
+                key={t.key}
+                type="button"
+                className="relative pb-[1.2rem]"
+                onClick={() => setTab(t.key)}
+              >
+                <span
+                  className={`body2 ${active ? 'text-black' : 'text-gray-400'}`}
+                >
+                  {t.label}
+                </span>
+                {active && (
+                  <span className="absolute right-0 bottom-0 left-0 h-[0.2rem] rounded-[999px] bg-black" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 리스트 */}
+      <main className="flex flex-col gap-[2rem] px-[2rem] pb-[8rem]">
+        {list.map((item) => (
+          <section key={item.id} className="flex flex-col gap-[0.8rem]">
+            <p className="caption1 text-gray-400">
+              {formatDateLine(item.orderedAt, item.status, item.method)}
+            </p>
+            <OrderCard item={item} onCancel={onCancel} onReorder={onReorder} />
+          </section>
+        ))}
+      </main>
+    </div>
+  );
 }

--- a/src/pages/order/order-page.tsx
+++ b/src/pages/order/order-page.tsx
@@ -5,7 +5,7 @@ import type { OrderItem } from './types/order';
 import OrderCard from './components/order-card';
 import OrderTabs from './components/order-tabs';
 import { useNavigate } from 'react-router-dom';
-
+import { useToast } from '@/shared/contexts/ToastContext';
 import { useOrdersQuery } from '@/shared/apis/order/order-queries';
 import { useCancelOrderMutation } from '@/shared/apis/order/order-mutations';
 import { mapOrderToUI } from '@/shared/utils/map-order-to-ui';
@@ -40,6 +40,7 @@ export default function OrderHistoryPage() {
 
   const { data, isFetching } = useOrdersQuery();
   const { mutate: cancelOrder } = useCancelOrderMutation();
+  const { showToast } = useToast();
 
   const list: OrderItem[] = useMemo(() => {
     const orders = data?.orders ?? [];
@@ -47,7 +48,17 @@ export default function OrderHistoryPage() {
   }, [data?.orders, tab]);
 
   const onCancel = (id: string) => {
-    cancelOrder({ orderId: id });
+    cancelOrder(
+      { orderId: id },
+      {
+        onSuccess: () => {
+          showToast('주문이 취소되었습니다.', 'success');
+        },
+        onError: () => {
+          showToast('주문 취소에 실패했습니다. 다시 시도해주세요.', 'error');
+        },
+      },
+    );
   };
 
   const onReorder = (id: string) => {

--- a/src/pages/order/order-page.tsx
+++ b/src/pages/order/order-page.tsx
@@ -1,86 +1,19 @@
 import { useMemo, useState } from 'react';
 import TopBar from '@/shared/layouts/top-bar';
-import { ORDER_STATUS, ORDER_TABS, type OrderTabKey } from './constants/order';
+import { ORDER_TABS, type OrderTabKey } from './constants/order';
 import type { OrderItem } from './types/order';
 import OrderCard from './components/order-card';
+import OrderTabs from './components/order-tabs';
 import { useNavigate } from 'react-router-dom';
 
-// --- 샘플 데이터 (API 연동 전 UI 확인용) ---
-const base: Omit<OrderItem, 'id' | 'orderedAt' | 'method' | 'status'> = {
-  image: '/sample/order-thumb.jpg',
-  store: '스타벅스 송실대입구역점',
-  name: '시크릿 런치 밀박스',
-  discountRate: 20,
-  salePrice: 10800,
-  originalPrice: 13500,
-  qty: 2,
-  savedGram: 560,
-  pickupPriceText: '픽업 시 9,800원',
-};
-
-const mockOrders: OrderItem[] = [
-  {
-    id: 'd1',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'delivery',
-    status: ORDER_STATUS.CANCELLABLE,
-    ...base,
-  },
-  {
-    id: 'd2',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'delivery',
-    status: ORDER_STATUS.IN_PROGRESS,
-    ...base,
-  },
-  {
-    id: 'd3',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'delivery',
-    status: ORDER_STATUS.DELIVERED,
-    ...base,
-  },
-  {
-    id: 'd4',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'delivery',
-    status: ORDER_STATUS.SOLD_OUT,
-    ...base,
-  },
-
-  {
-    id: 'p1',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'pickup',
-    status: ORDER_STATUS.CANCELLABLE,
-    ...base,
-  },
-  {
-    id: 'p2',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'pickup',
-    status: ORDER_STATUS.IN_PROGRESS,
-    ...base,
-  },
-  {
-    id: 'p3',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'pickup',
-    status: ORDER_STATUS.DELIVERED,
-    ...base,
-  },
-  {
-    id: 'p4',
-    orderedAt: '2025-08-16T22:16:00+09:00',
-    method: 'pickup',
-    status: ORDER_STATUS.SOLD_OUT,
-    ...base,
-  },
-];
+import { useOrdersQuery } from '@/shared/apis/order/order-queries';
+import { useCancelOrderMutation } from '@/shared/apis/order/order-mutations';
+import { mapOrderToUI } from '@/shared/utils/map-order-to-ui';
+import { ORDER_STATUS } from './constants/order';
 
 const formatDateLine = (
   iso: string,
-  status: string,
+  status: OrderItem['status'],
   method: OrderItem['method'],
 ) => {
   const d = new Date(iso);
@@ -105,12 +38,20 @@ export default function OrderHistoryPage() {
   const navigate = useNavigate();
   const [tab, setTab] = useState<OrderTabKey>('delivery');
 
-  const list = useMemo(() => mockOrders.filter((o) => o.method === tab), [tab]);
+  const { data, isFetching } = useOrdersQuery();
+  const { mutate: cancelOrder } = useCancelOrderMutation();
+
+  const list: OrderItem[] = useMemo(() => {
+    const orders = data?.orders ?? [];
+    return orders.filter((o) => o.orderType === tab).map(mapOrderToUI);
+  }, [data?.orders, tab]);
 
   const onCancel = (id: string) => {
-    console.log('cancel', id);
+    cancelOrder({ orderId: id });
   };
+
   const onReorder = (id: string) => {
+    // TODO: 재주문 흐름 연결
     console.log('reorder', id);
   };
 
@@ -118,33 +59,16 @@ export default function OrderHistoryPage() {
     <div className="scrollbar-hide h-dvh flex-col overflow-y-auto bg-white">
       <TopBar title="주문내역" showBack onBack={() => navigate(-1)} sticky />
 
-      <div className="px-[2rem]">
-        <div className="flex h-[4.8rem] items-center gap-[2.4rem]">
-          {ORDER_TABS.map((t) => {
-            const active = t.key === tab;
-            return (
-              <button
-                key={t.key}
-                type="button"
-                className="relative pb-[1.2rem]"
-                onClick={() => setTab(t.key)}
-              >
-                <span
-                  className={`body2 ${active ? 'text-black' : 'text-gray-400'}`}
-                >
-                  {t.label}
-                </span>
-                {active && (
-                  <span className="absolute right-0 bottom-0 left-0 h-[0.2rem] rounded-[999px] bg-black" />
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+      <OrderTabs
+        tabs={ORDER_TABS}
+        active={tab}
+        onChange={setTab}
+        topOffsetRem={4.4}
+      />
 
-      {/* 리스트 */}
-      <main className="flex flex-col gap-[2rem] px-[2rem] pb-[8rem]">
+      <main className="flex flex-col gap-[2rem] px-[2rem] py-[1.6rem]">
+        {isFetching && <p className="caption1 text-gray-400">불러오는 중…</p>}
+
         {list.map((item) => (
           <section key={item.id} className="flex flex-col gap-[0.8rem]">
             <p className="caption1 text-gray-400">
@@ -153,6 +77,12 @@ export default function OrderHistoryPage() {
             <OrderCard item={item} onCancel={onCancel} onReorder={onReorder} />
           </section>
         ))}
+
+        {!isFetching && list.length === 0 && (
+          <p className="caption1 py-[2.4rem] text-center text-gray-400">
+            주문 내역이 없어요.
+          </p>
+        )}
       </main>
     </div>
   );

--- a/src/pages/order/types/order.ts
+++ b/src/pages/order/types/order.ts
@@ -1,0 +1,23 @@
+export interface OrderItem {
+  id: string;
+  orderedAt: string; // ISO string
+  method: 'delivery' | 'pickup';
+  status: import('../constants/order').OrderStatus;
+
+  // 상품
+  image: string;
+  store: string;
+  name: string;
+
+  // 가격
+  discountRate: number; // 20
+  salePrice: number; // 10800
+  originalPrice: number; // 13500
+  qty: number; // 2
+
+  // 픽업 탭 전용 문구 (ex. "픽업 시 9,800원")
+  pickupPriceText?: string;
+
+  // 절약 무게 배지
+  savedGram: number; // 560
+}

--- a/src/shared/apis/constants/endpoints.ts
+++ b/src/shared/apis/constants/endpoints.ts
@@ -15,6 +15,9 @@ export const END_POINT = {
   DISCOVER_FILTER: `/discover/filter`,
   DISCOVER_AI_RECOMMEND: `/discover/ai-recommend`,
   ORDER_CREATE: '/order',
+  ORDER_LIST: '/order',
+  ORDER_DETAIL: (orderId: string) => `\/order/${orderId}`,
+  ORDER_CANCEL: (orderId: string) => `/order/${orderId}`,
 } as const;
 
 export const withBase = (path: string): string =>

--- a/src/shared/apis/constants/keys.ts
+++ b/src/shared/apis/constants/keys.ts
@@ -7,3 +7,12 @@ export const AUTH_KEY = {
 } as const;
 
 export type AuthQueryKey = ReturnType<typeof AUTH_KEY.ME>;
+
+export const ORDER_KEY = {
+  ALL: ['order'] as const,
+  LIST: () => [...ORDER_KEY.ALL, 'list'] as const,
+  DETAIL: (orderId: string) => [...ORDER_KEY.ALL, 'detail', orderId] as const,
+} as const;
+
+export type OrderListKey = ReturnType<typeof ORDER_KEY.LIST>;
+export type OrderDetailKey = ReturnType<typeof ORDER_KEY.DETAIL>;

--- a/src/shared/apis/order/order-mutations.ts
+++ b/src/shared/apis/order/order-mutations.ts
@@ -1,8 +1,15 @@
-import { useMutation } from '@tanstack/react-query';
-import { api } from '../factory';
-import type { CreateOrderBody, CreateOrderResponse } from './order';
+// src/shared/apis/order/order-mutations.ts  (취소 훅)
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/shared/apis/factory';
+import { ORDER_KEY } from '@/shared/apis/constants/keys';
+import type { CancelOrderResponse } from './order';
 
-export const useCreateOrderMutation = () =>
-  useMutation<CreateOrderResponse, unknown, CreateOrderBody>({
-    mutationFn: (body) => api.order.create(body),
+export const useCancelOrderMutation = () => {
+  const qc = useQueryClient();
+  return useMutation<CancelOrderResponse, Error, { orderId: string }>({
+    mutationFn: ({ orderId }) => api.order.cancel(orderId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ORDER_KEY.LIST() });
+    },
   });
+};

--- a/src/shared/apis/order/order-queries.ts
+++ b/src/shared/apis/order/order-queries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/shared/apis/factory';
+import { ORDER_KEY } from '@/shared/apis/constants/keys';
+import type { OrdersResponse } from './order';
+
+export const useOrdersQuery = () =>
+  useQuery<OrdersResponse>({
+    queryKey: ORDER_KEY.LIST(),
+    queryFn: () => api.order.list(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });

--- a/src/shared/apis/order/order.ts
+++ b/src/shared/apis/order/order.ts
@@ -1,6 +1,8 @@
+// src/shared/apis/order/order.ts
 import { END_POINT } from '@/shared/apis/constants/endpoints';
 import type { HttpClient } from '@/shared/apis/base/http';
 
+/** 주문 생성 */
 export type CreateOrderBody = {
   menuId: string;
   quantity: number;
@@ -39,10 +41,77 @@ export type CreateOrderResponse = {
   };
 };
 
+/** 주문 공통 모델 (목록/상세용) */
+export type OrderItemApi = {
+  orderId: string;
+  storeId: string;
+  storeName: string;
+  items: Array<{
+    menuId: string;
+    menuName: string;
+    quantity: number;
+    gramPerUnit: number;
+    unitPrice: number;
+    totalPrice: number;
+    totalGrams: number;
+    menuImageUrls?: string[];
+    originalMenuPrice?: number;
+    originalTotalPrice?: number;
+    discountedMenuPrice?: number;
+    discountedPercentage?: number;
+    pickupPrice?: number;
+    currentStockLeft?: number;
+  }>;
+  orderType: 'pickup' | 'delivery';
+  paymentMethod: 'card' | 'onsite';
+  totalQuantity: number;
+  totalAmount: number;
+  totalGrams: number;
+  finalAmount: number;
+  status: string; // ex) 'pending' | 'delivered' ...
+  orderDate: string; // "YYYYMMDD HH:mm:ss"
+};
+
+export type OrdersResponse = {
+  success: boolean;
+  message: string;
+  orders: OrderItemApi[];
+  totalCount: number;
+};
+
+export type OrderDetailResponse = {
+  success: boolean;
+  message: string;
+  order: OrderItemApi;
+};
+
+export type CancelOrderResponse = {
+  success: boolean;
+  message: string;
+  cancelledOrder: {
+    orderId: string;
+    storeName: string;
+    finalAmount: number;
+    cancelledAt: string; // "YYYYMMDD HH:mm:ss"
+  };
+};
+
 export const createOrderApi = (http: HttpClient) => ({
+  /** 주문 생성 */
   create: (body: CreateOrderBody) =>
     http.post<CreateOrderResponse, CreateOrderBody>(
       END_POINT.ORDER_CREATE,
       body,
     ),
+
+  /** 주문 목록 */
+  list: () => http.get<OrdersResponse>(END_POINT.ORDER_LIST),
+
+  /** 주문 상세 */
+  detail: (orderId: string) =>
+    http.get<OrderDetailResponse>(END_POINT.ORDER_DETAIL(orderId)),
+
+  /** 주문 취소 */
+  cancel: (orderId: string) =>
+    http.delete<CancelOrderResponse>(END_POINT.ORDER_CANCEL(orderId)),
 });

--- a/src/shared/components/toast.tsx
+++ b/src/shared/components/toast.tsx
@@ -1,0 +1,42 @@
+import Icon from './icon';
+export type ToastType = 'success' | 'info' | 'error';
+
+interface ToastProps {
+  type: ToastType;
+  message: string;
+}
+
+const toastStyles = {
+  success: {
+    icon: <Icon name="toast-success" size={1.1} className="text-white" />,
+    iconBg: 'bg-[#769dff]',
+    bg: 'bg-gray-800',
+  },
+  info: {
+    icon: <Icon name="toast-info" size={1.1} className="text-white" />,
+    iconBg: 'bg-[#DCA048]',
+    bg: 'bg-gray-800',
+  },
+  error: {
+    icon: <Icon name="toast-close" size={1.1} className="text-white" />,
+    iconBg: 'bg-[#FF5656]',
+    bg: 'bg-gray-800',
+  },
+};
+
+export default function Toast({ type, message }: ToastProps) {
+  const { icon, iconBg, bg } = toastStyles[type];
+
+  return (
+    <div
+      className={`inline-flex w-full items-center gap-[0.8rem] rounded-[8px] px-[1.6rem] py-[1.2rem] shadow-md ${bg}`}
+    >
+      <div
+        className={`flex h-[2rem] w-[2rem] items-center justify-center rounded-full ${iconBg}`}
+      >
+        {icon}
+      </div>
+      <span className="caption2 text-white">{message}</span>
+    </div>
+  );
+}

--- a/src/shared/contexts/ToastContext.tsx
+++ b/src/shared/contexts/ToastContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useState, useMemo, ReactNode } from 'react';
+
+import { createPortal } from 'react-dom';
+
+import Toast from '@/shared/components/toast';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface ToastMessage {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastContextProps {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextProps | undefined>(undefined);
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const showToast = (message: string, type: ToastType = 'success') => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, type, message }]);
+
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, 3000);
+  };
+
+  const contextValue = useMemo(() => ({ showToast }), []);
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      {createPortal(
+        <div className="fixed bottom-[10rem] left-1/2 z-30 w-full max-w-[430px] -translate-x-1/2 space-y-[1.2rem] px-[2.5rem]">
+          {toasts.map((toast) => (
+            <Toast key={toast.id} type={toast.type} message={toast.message} />
+          ))}
+        </div>,
+        document.body,
+      )}
+    </ToastContext.Provider>
+  );
+}

--- a/src/shared/utils/map-order-to-ui.ts
+++ b/src/shared/utils/map-order-to-ui.ts
@@ -1,0 +1,55 @@
+// src/shared/utils/mapOrderToUI.ts  (API → UI 모델 매핑 유틸)
+import type { OrderItemApi } from '@/shared/apis/order/order';
+import { ORDER_STATUS } from '@/pages/order/constants/order';
+import type { OrderItem } from '@/pages/order/types/order';
+
+// "YYYYMMDD HH:mm:ss" → ISO
+const toIsoKst = (s: string) => {
+  // 20250822 11:18:56
+  const [date, time] = s.split(' ');
+  const y = date.slice(0, 4);
+  const m = date.slice(4, 6);
+  const d = date.slice(6, 8);
+  // KST로 해석해 ISO로 변환
+  return new Date(`${y}-${m}-${d}T${time}+09:00`).toISOString();
+};
+
+// API status → UI status 대략 매핑
+const mapStatus = (api: OrderItemApi): OrderItem['status'] => {
+  const soldOut = api.items?.some((it) => it.currentStockLeft === 0);
+  if (soldOut) return ORDER_STATUS.SOLD_OUT;
+  if (api.status === 'delivered') return ORDER_STATUS.DELIVERED;
+  // cancel 가능 여부가 따로 오지 않으므로 pending은 진행중으로 처리
+  if (api.status === 'pending') return ORDER_STATUS.IN_PROGRESS;
+  return ORDER_STATUS.IN_PROGRESS;
+};
+
+export const mapOrderToUI = (o: OrderItemApi): OrderItem => {
+  const first = o.items?.[0];
+  const qty = first?.quantity ?? o.totalQuantity ?? 1;
+  const discountRate = first?.discountedPercentage ?? 0;
+  const salePrice = o.totalAmount ?? first?.totalPrice ?? 0;
+  const originalPrice =
+    first?.originalTotalPrice ?? (first?.originalMenuPrice ?? 0) * qty;
+
+  const pickupPriceText =
+    o.orderType === 'pickup' && first?.pickupPrice
+      ? `픽업 시 ${first.pickupPrice.toLocaleString()}원`
+      : undefined;
+
+  return {
+    id: o.orderId,
+    orderedAt: toIsoKst(o.orderDate),
+    method: o.orderType, // 'pickup' | 'delivery'
+    status: mapStatus(o),
+    image: first?.menuImageUrls?.[0] ?? '',
+    store: o.storeName,
+    name: first?.menuName ?? '',
+    discountRate,
+    salePrice,
+    originalPrice,
+    qty,
+    savedGram: o.totalGrams ?? first?.totalGrams ?? 0,
+    pickupPriceText,
+  };
+};


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #70

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?

- 주문 목록 페이지 UI 구현
- 주문 취소/조회 API 연동
- Toast(성공/실패) 적용


## 💡 해결한 이슈 목록

- [x] 주문 목록 API 연동 (GET /api/order)
- [x] 주문 취소 연동 (DELETE /api/order/:orderId)
- [x] 토스트 적용


## ✅ 변경사항
- END_POINT: ORDER_CREATE, ORDER_LIST, ORDER_DETAIL(id), ORDER_CANCEL(id) 추가
- ORDER_KEY: LIST(), DETAIL(id) 추가
- createOrderApi: create/list/detail/cancel 메서드 추가
- useOrdersQuery, useCancelOrderMutation 구현
- OrderHistoryPage에 실제 목록 연동, mock 제거
- 탭을 OrderTabs 컴포넌트로 분리(sticky, TopBar 아래 고정, 전체 너비)
- API→UI 매핑 유틸 map-order-to-ui.ts 추가
- ToastProvider 추가 및 주문 취소 성공 시 토스트 노출

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

